### PR TITLE
Fix handling of many graph nodes at the same location

### DIFF
--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -284,6 +284,7 @@ fn finalize_index_build<S: Storage>(
                     if neighbors.len() > state.graph.get_meta_page().get_num_neighbors() as _ {
                         //OPT: get rid of this clone
                         prune_neighbors = state.graph.prune_neighbors(
+                            index_pointer,
                             neighbors.clone(),
                             storage,
                             &mut write_stats.prune_stats,
@@ -833,6 +834,103 @@ pub mod tests {
 
         assert!(cnt.unwrap() == expected_cnt, "after update count");
 
+        Ok(())
+    }
+
+    #[pg_test]
+    pub unsafe fn test_index_small_accuracy() -> spi::Result<()> {
+        /* Test for the creation of connected graphs when the number of dimensions is small as is the
+        number of neighborss */
+        /* small num_neighbors is especially challenging for making sure no nodes get disconnected */
+        let index_options = "num_neighbors=10, search_list_size=10";
+        let expected_cnt = 300;
+        let dimensions = 2;
+
+        Spi::run(&format!(
+            "CREATE TABLE test_data (
+                id int,
+                embedding vector ({dimensions})
+            );
+
+            select setseed(0.5);
+           -- generate 300 vectors
+            INSERT INTO test_data (id, embedding)
+            SELECT
+                *
+            FROM (
+                SELECT
+                    i % {expected_cnt},
+                    ('[' || array_to_string(array_agg(random()), ',', '0') || ']')::vector AS embedding
+                FROM
+                    generate_series(1, {dimensions} * {expected_cnt}) i
+                GROUP BY
+                    i % {expected_cnt}) g;
+
+            CREATE INDEX idx_diskann_bq ON test_data USING diskann (embedding) WITH ({index_options});
+
+
+            SET enable_seqscan = 0;
+            -- perform index scans on the vectors
+            SELECT
+                *
+            FROM
+                test_data
+            ORDER BY
+                embedding <=> (
+                    SELECT
+                        ('[' || array_to_string(array_agg(random()), ',', '0') || ']')::vector AS embedding
+            FROM generate_series(1, {dimensions}));"))?;
+
+        let test_vec: Option<Vec<f32>> = Spi::get_one(&format!(
+            "SELECT('{{' || array_to_string(array_agg(1.0), ',', '0') || '}}')::real[] AS embedding
+    FROM generate_series(1, {dimensions})"
+        ))?;
+
+        let cnt: Option<i64> = Spi::get_one_with_args(
+                &format!(
+                    "
+            SET enable_seqscan = 0;
+            SET enable_indexscan = 1;
+            SET diskann.query_search_list_size = 2;
+            WITH cte as (select * from test_data order by embedding <=> $1::vector) SELECT count(*) from cte;
+            ",
+                ),
+                vec![(
+                    pgrx::PgOid::Custom(pgrx::pg_sys::FLOAT4ARRAYOID),
+                    test_vec.clone().into_datum(),
+                )],
+            )?;
+
+        if cnt.unwrap() != expected_cnt {
+            /* better debugging */
+            let id: Option<i64> = Spi::get_one_with_args(
+                &format!(
+                    "
+            SET enable_seqscan = 0;
+            SET enable_indexscan = 1;
+            SET diskann.query_search_list_size = 2;
+            WITH cte as (select id from test_data EXCEPT (select id from test_data order by embedding <=> $1::vector)) SELECT id from cte limit 1;
+            ",
+                ),
+                vec![(
+                    pgrx::PgOid::Custom(pgrx::pg_sys::FLOAT4ARRAYOID),
+                    test_vec.clone().into_datum(),
+                )],
+            )?;
+
+            assert!(
+                cnt.unwrap() == expected_cnt,
+                "initial count is {} id is {}",
+                cnt.unwrap(),
+                id.unwrap()
+            );
+        }
+
+        assert!(
+            cnt.unwrap() == expected_cnt,
+            "initial count is {}",
+            cnt.unwrap()
+        );
         Ok(())
     }
 }

--- a/pgvectorscale/src/util/mod.rs
+++ b/pgvectorscale/src/util/mod.rs
@@ -121,6 +121,16 @@ impl ItemPointer {
             len: len as _,
         }
     }
+
+    pub fn ip_distance(self, other: Self) -> usize {
+        /* distance measure based on on-disk distance */
+        /* The two abs() give better results than taking one abs() at the end. Not quite sure why but I think
+         * It creates more links within the equivalence class  */
+        let block_diff = (self.block_number as isize - other.block_number as isize).abs() as usize;
+        let offset_diff = (self.offset as isize - other.offset as isize).abs() as usize;
+        debug_assert!(offset_diff < pgrx::pg_sys::MaxOffsetNumber as _);
+        (block_diff * (pgrx::pg_sys::MaxOffsetNumber as usize) + offset_diff) as usize
+    }
 }
 
 pub type IndexPointer = ItemPointer;


### PR DESCRIPTION
When nodes have the same location, their distance to each other is 0. And, their distance to all their neighbors is the same. In the case with few maximum neighbors this can cause problems because the nodes end up linking to each other and getting cut off from the rest of the graph.

We fix this by introducing a secondary "tie break" distance between nodes at the same location (based on on-disk distance). That's used to create a secondary ordering for equivalent nodes and allows the prune function to then properly cut away equivalent nodes so that your neighbor list doesn't get full of them.

Note with SBQ, equivalence classes are actually not /so/ rare especially with low dimension counts.