### PR TITLE
Panic if AVX or FMA is missing

### DIFF
--- a/.github/actions/install-pgvector/action.yml
+++ b/.github/actions/install-pgvector/action.yml
@@ -1,0 +1,36 @@
+name: "Install pgvector "
+description: "Builds and installs Pgvector"
+
+inputs:
+  pgvector-version:
+    required: true
+    description: "pgvector version"
+  pgvector-src-dir:
+    default: pgvectorbuild
+  pg-install-dir:
+    default: postgresql
+
+runs:
+  using: "composite"
+  steps:
+    
+    - name: Build Pgvector ${{ inputs.pgvector-version }}
+      shell: bash
+      env:
+        pg_build_args: --enable-debug --enable-cassert
+        llvm_config: llvm-config-14
+        CC: gcc
+        CXX: g++
+      run: |
+        export PATH=${{ inputs.pg-install-dir }}/bin:$PATH
+        mkdir -p ${{ inputs.pgvector-src-dir }}
+        cd ${{ inputs.pgvector-src-dir }}
+        git clone --branch v${{ inputs.pgvector-version }} https://github.com/pgvector/pgvector.git
+        cd pgvector
+        make -j$(nproc)
+
+    - name: Install pgvector ${{ inputs.pgvector-version }}
+      shell: bash
+      run: |
+        export PATH=${{ inputs.pg-install-dir }}/bin:$PATH
+        make -C ${{ inputs.pgvector-src-dir }}/pgvector install

--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -1,0 +1,68 @@
+name: Run PGRX tests
+on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
+
+jobs:
+  tester:
+    runs-on: ${{ matrix.platform.runs_on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        pgvector:
+          - version: 0.7.4
+        pg:
+          - major: 15
+            minor: 7
+          - major: 16
+            minor: 3
+        platform:
+          - type: amd64
+            runs_on: ubuntu-latest
+            rustflags: '-C target-feature=+avx2,+fma'
+          - type: arm64
+            runs_on: cloud-image-runner-arm64
+            rustflags: ''
+
+    env:
+      PG_SRC_DIR: pgbuild
+      PG_INSTALL_DIR: postgresql
+      MAKE_JOBS: 6
+      PG_CONFIG_PATH: postgresql/bin/pg_config
+      TAG: ${{ github.event.inputs.tag }}
+      TAG_DIR: pgvectorscale
+      TAG_GIT_REF: ${{ github.event.inputs.TAG_GIT_REF == '' && github.event.inputs.tag || github.event.inputs.TAG_GIT_REF}}
+
+    steps:
+    - name: Checkout pgvectorscale
+      uses: actions/checkout@v4
+
+    - name: Install Linux Packages
+      uses: ./.github/actions/install-packages
+
+    - name: Install PostgreSQL ${{ matrix.pg.major }}
+      uses: ./.github/actions/install-postgres
+      with:
+        pg-version: ${{ matrix.pg.major }}.${{ matrix.pg.minor }}
+        pg-src-dir: ~/${{ env.PG_SRC_DIR }}
+        pg-install-dir: ~/${{ env.PG_INSTALL_DIR }}
+      
+    - name: Install pgvector ${{ matrix.pgvector.version }}
+      uses: ./.github/actions/install-pgvector
+      with:
+        pgvector-version: ${{ matrix.pgvector.version }}
+        pg-install-dir: ~/${{ env.PG_INSTALL_DIR }}
+
+    - name: Install pgrx
+      uses: ./.github/actions/install-pgrx
+      with:
+        pg-install-dir: ~/${{ env.PG_INSTALL_DIR }}
+        pgrx-version: 0.11.1
+
+    - name: Run tests
+      id: runtests 
+      run: |
+        cd pgvectorscale
+        ls
+        ${{ matrix.platform.rustflags != '' && format('RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }} cargo pgrx test -- pg${{ matrix.pg.major }}

--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -64,5 +64,5 @@ jobs:
       id: runtests 
       run: |
         cd pgvectorscale
-        ls
-        ${{ matrix.platform.rustflags != '' && format('RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }} cargo pgrx test -- pg${{ matrix.pg.major }}
+        ${{ matrix.platform.rustflags != '' && format('export RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }} 
+        cargo pgrx test -- pg${{ matrix.pg.major }}

--- a/pgvectorscale/src/access_method/distance.rs
+++ b/pgvectorscale/src/access_method/distance.rs
@@ -5,6 +5,13 @@ compile_error!(
     "On x86, the AVX2 feature must be enabled. Set RUSTFLAGS=\"-C target-feature=+avx2,+fma\""
 );
 
+pub fn init() {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    if (!is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma")) {
+        panic!("On x86, pgvectorscale requires the CPU to support AVX2 and FMA. See https://github.com/timescale/pgvectorscale/issues/115");
+    }
+}
+
 #[inline]
 pub fn distance_l2(a: &[f32], b: &[f32]) -> f32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/pgvectorscale/src/access_method/distance.rs
+++ b/pgvectorscale/src/access_method/distance.rs
@@ -1,13 +1,14 @@
 /* we use the avx2 version of x86 functions. This verifies that's kosher */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(not(target_feature = "avx2"))]
+#[cfg(not(doc))]
 compile_error!(
     "On x86, the AVX2 feature must be enabled. Set RUSTFLAGS=\"-C target-feature=+avx2,+fma\""
 );
 
 pub fn init() {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    if (!is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma")) {
+    if !is_x86_feature_detected!("avx2") || !is_x86_feature_detected!("fma") {
         panic!("On x86, pgvectorscale requires the CPU to support AVX2 and FMA. See https://github.com/timescale/pgvectorscale/issues/115");
     }
 }

--- a/pgvectorscale/src/access_method/distance_x86.rs
+++ b/pgvectorscale/src/access_method/distance_x86.rs
@@ -7,12 +7,14 @@ use simdeez::sse41::*;
 use simdeez::avx2::*;
 
 #[cfg(not(target_feature = "avx2"))]
+#[cfg(not(doc))]
 compile_error!(
     "On x86, the AVX2 feature must be enabled. Set RUSTFLAGS=\"-C target-feature=+avx2,+fma\""
 );
 
 //note: without fmadd, the performance degrades pretty badly. Benchmark before disbaling
 #[cfg(not(target_feature = "fma"))]
+#[cfg(not(doc))]
 compile_error!(
     "On x86, the fma feature must be enabled. Set RUSTFLAGS=\"-C target-feature=+avx2,+fma\""
 );

--- a/pgvectorscale/src/access_method/distance_x86.rs
+++ b/pgvectorscale/src/access_method/distance_x86.rs
@@ -132,33 +132,6 @@ simdeez::simd_runtime_generate!(
 mod tests {
     #[test]
     fn distances_equal() {
-        let r: Vec<f32> = (0..2000).map(|_| 1.0).collect();
-        let l: Vec<f32> = (0..2000).map(|_| 2.0).collect();
-
-        assert_eq!(
-            unsafe { super::distance_cosine_x86_avx2(&r, &l) },
-            super::super::distance::distance_cosine_unoptimized(&r, &l)
-        );
-
-        assert_eq!(
-            unsafe { super::distance_l2_x86_avx2(&r, &l) },
-            super::super::distance::distance_l2_unoptimized(&r, &l)
-        );
-
-        //don't use too many dimensions to avoid overflow
-        let r: Vec<f32> = (0..20).map(|v| v as f32).collect();
-        let l: Vec<f32> = (0..20).map(|v| v as f32).collect();
-
-        assert_eq!(
-            unsafe { super::distance_cosine_x86_avx2(&r, &l) },
-            super::super::distance::distance_cosine_unoptimized(&r, &l)
-        );
-        assert_eq!(
-            unsafe { super::distance_l2_x86_avx2(&r, &l) },
-            super::super::distance::distance_l2_unoptimized(&r, &l)
-        );
-
-        //many dimensions but normalized
         let r: Vec<f32> = (0..2000).map(|v| v as f32 + 1.0).collect();
         let l: Vec<f32> = (0..2000).map(|v| v as f32 + 2.0).collect();
 

--- a/pgvectorscale/src/lib.rs
+++ b/pgvectorscale/src/lib.rs
@@ -8,6 +8,7 @@ mod util;
 #[allow(non_snake_case)]
 #[pg_guard]
 pub unsafe extern "C" fn _PG_init() {
+    access_method::distance::init();
     access_method::options::init();
     access_method::guc::init();
 }


### PR DESCRIPTION
Our compilation on x86 enables fma and avx in target-feature. We should panic if the running CPU is actually missing the feature because otherwise the behavior is undefined and in practice we've seen segfaults.

The panic will be translated to a Postgres error.