### PR TITLE
Bump pgrx version to 0.12.5

### DIFF
--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -69,7 +69,7 @@ jobs:
       uses: ./.github/actions/install-pgrx
       with:
         pg-install-dir: ~/${{ env.PG_INSTALL_DIR }}
-        pgrx-version: 0.11.1
+        pgrx-version: 0.12.5
 
     - name: Build Deb
       id: debbuild

--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -58,7 +58,7 @@ jobs:
       uses: ./.github/actions/install-pgrx
       with:
         pg-install-dir: ~/${{ env.PG_INSTALL_DIR }}
-        pgrx-version: 0.11.1
+        pgrx-version: 0.12.5
 
     - name: Run tests
       id: runtests 

--- a/pgvectorscale/Cargo.toml
+++ b/pgvectorscale/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "pgrx_embed_vectorscale"
+path = "./src/bin/pgrx_embed.rs"
+
 [features]
 default = ["pg16"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
@@ -14,16 +18,17 @@ pg_test = []
 
 [dependencies]
 memoffset = "0.9.0"
-pgrx = "=0.11.4"
+pgrx = "=0.12.5"
 rkyv = { version="0.7.42", features=["validation"]}
 simdeez = {version = "1.0.8"}
 rand = { version = "0.8", features = [ "small_rng" ] }
 pgvectorscale_derive = { path = "pgvectorscale_derive" }
 semver = "1.0.22"
+once_cell = "1.20.1"
 
 [dev-dependencies]
-pgrx-tests = "=0.11.4"
-pgrx-pg-config = "=0.11.4"
+pgrx-tests = "=0.12.5"
+pgrx-pg-config = "=0.12.5"
 criterion = "0.5.1"
 tempfile = "3.3.0"
 

--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn aminsert(
     isnull: *mut bool,
     heap_tid: pg_sys::ItemPointer,
     heaprel: pg_sys::Relation,
-    _check_unique: pg_sys::IndexUniqueCheck,
+    _check_unique: pg_sys::IndexUniqueCheck::Type,
     _index_info: *mut pg_sys::IndexInfo,
 ) -> bool {
     aminsert_internal(indexrel, values, isnull, heap_tid, heaprel)

--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -484,11 +484,11 @@ pub unsafe extern "C" fn ambuildphasename(phasenum: i64) -> *mut ffi::c_char {
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 pub mod tests {
-    use std::collections::HashSet;
+    // use std::collections::HashSet;
 
     use pgrx::*;
 
-    use crate::util::ItemPointer;
+    // use crate::util::ItemPointer;
 
     //TODO: add test where inserting and querying with vectors that are all the same.
 

--- a/pgvectorscale/src/access_method/mod.rs
+++ b/pgvectorscale/src/access_method/mod.rs
@@ -107,7 +107,8 @@ END;
 $$;
 
 "#,
-    name = "diskann_ops_operator"
+    name = "diskann_ops_operator",
+    requires = [amhandler]
 );
 
 #[pg_guard]

--- a/pgvectorscale/src/access_method/options.rs
+++ b/pgvectorscale/src/access_method/options.rs
@@ -1,5 +1,5 @@
 use memoffset::*;
-use pgrx::{pg_sys::AsPgCStr, prelude::*, set_varsize, void_ptr, PgRelation};
+use pgrx::{pg_sys::AsPgCStr, prelude::*, set_varsize_4b, void_ptr, PgRelation};
 use std::{ffi::CStr, fmt::Debug};
 
 use super::storage::StorageType;
@@ -41,7 +41,7 @@ impl TSVIndexOptions {
             ops.num_dimensions = NUM_DIMENSIONS_DEFAULT_SENTINEL;
             ops.bq_num_bits_per_dimension = SBQ_NUM_BITS_PER_DIMENSION_DEFAULT_SENTINEL;
             unsafe {
-                set_varsize(
+                set_varsize_4b(
                     ops.as_ptr().cast(),
                     std::mem::size_of::<TSVIndexOptions>() as i32,
                 );
@@ -87,7 +87,7 @@ impl TSVIndexOptions {
 }
 
 const NUM_REL_OPTS: usize = 6;
-static mut RELOPT_KIND_TSV: pg_sys::relopt_kind = 0;
+static mut RELOPT_KIND_TSV: pg_sys::relopt_kind::Type = 0;
 
 // amoptions is a function that gets a datum of text[] data from pg_class.reloptions (which contains text in the format "key=value") and returns a bytea for the struct for the parsed options.
 // this is used to fill the rd_options field in the index relation.
@@ -108,32 +108,32 @@ pub unsafe extern "C" fn amoptions(
     let tab: [pg_sys::relopt_parse_elt; NUM_REL_OPTS] = [
         pg_sys::relopt_parse_elt {
             optname: "storage_layout".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_STRING,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
             offset: offset_of!(TSVIndexOptions, storage_layout_offset) as i32,
         },
         pg_sys::relopt_parse_elt {
             optname: "num_neighbors".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_INT,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
             offset: offset_of!(TSVIndexOptions, num_neighbors) as i32,
         },
         pg_sys::relopt_parse_elt {
             optname: "search_list_size".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_INT,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
             offset: offset_of!(TSVIndexOptions, search_list_size) as i32,
         },
         pg_sys::relopt_parse_elt {
             optname: "num_dimensions".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_INT,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
             offset: offset_of!(TSVIndexOptions, num_dimensions) as i32,
         },
         pg_sys::relopt_parse_elt {
             optname: "num_bits_per_dimension".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_INT,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
             offset: offset_of!(TSVIndexOptions, bq_num_bits_per_dimension) as i32,
         },
         pg_sys::relopt_parse_elt {
             optname: "max_alpha".as_pg_cstr(),
-            opttype: pg_sys::relopt_type_RELOPT_TYPE_REAL,
+            opttype: pg_sys::relopt_type::RELOPT_TYPE_REAL,
             offset: offset_of!(TSVIndexOptions, max_alpha) as i32,
         },
     ];

--- a/pgvectorscale/src/access_method/scan.rs
+++ b/pgvectorscale/src/access_method/scan.rs
@@ -365,7 +365,7 @@ pub extern "C" fn amrescan(
 #[pg_guard]
 pub extern "C" fn amgettuple(
     scan: pg_sys::IndexScanDesc,
-    _direction: pg_sys::ScanDirection,
+    _direction: pg_sys::ScanDirection::Type,
 ) -> bool {
     let scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
     let state = unsafe { (scan.opaque as *mut TSVScanState).as_mut() }.expect("no scandesc state");

--- a/pgvectorscale/src/access_method/vacuum.rs
+++ b/pgvectorscale/src/access_method/vacuum.rs
@@ -33,7 +33,7 @@ pub extern "C" fn ambulkdelete(
     let nblocks = unsafe {
         pg_sys::RelationGetNumberOfBlocksInFork(
             index_relation.as_ptr(),
-            pg_sys::ForkNumber_MAIN_FORKNUM,
+            pg_sys::ForkNumber::MAIN_FORKNUM,
         )
     };
 
@@ -127,7 +127,7 @@ pub extern "C" fn amvacuumcleanup(
 
         (*stats).num_pages = pg_sys::RelationGetNumberOfBlocksInFork(
             index_relation.as_ptr(),
-            pg_sys::ForkNumber_MAIN_FORKNUM,
+            pg_sys::ForkNumber::MAIN_FORKNUM,
         );
 
         stats

--- a/pgvectorscale/src/bin/pgrx_embed.rs
+++ b/pgvectorscale/src/bin/pgrx_embed.rs
@@ -1,0 +1,1 @@
+::pgrx::pgrx_embed!();

--- a/pgvectorscale/src/util/buffer.rs
+++ b/pgvectorscale/src/util/buffer.rs
@@ -8,8 +8,7 @@ use std::ops::Deref;
 use pgrx::*;
 
 use pgrx::pg_sys::{
-    BlockNumber, Buffer, BufferGetBlockNumber, ForkNumber_MAIN_FORKNUM, InvalidBlockNumber,
-    ReadBufferMode_RBM_NORMAL,
+    BlockNumber, Buffer, BufferGetBlockNumber, ForkNumber, InvalidBlockNumber, ReadBufferMode,
 };
 
 pub struct LockRelationForExtension<'a> {
@@ -74,13 +73,13 @@ impl<'a> LockedBufferExclusive<'a> {
 
     /// Safety: unsafe because tje block number is not verifiwed
     unsafe fn read_unchecked(index: &'a PgRelation, block: BlockNumber) -> Self {
-        let fork_number = ForkNumber_MAIN_FORKNUM;
+        let fork_number = ForkNumber::MAIN_FORKNUM;
 
         let buf = pg_sys::ReadBufferExtended(
             index.as_ptr(),
             fork_number,
             block,
-            ReadBufferMode_RBM_NORMAL,
+            ReadBufferMode::RBM_NORMAL,
             std::ptr::null_mut(),
         );
 
@@ -95,13 +94,13 @@ impl<'a> LockedBufferExclusive<'a> {
     /// Obtaining this lock is more restrictive. It will only be obtained once the pin
     /// count is 1. Refer to the PG code for `LockBufferForCleanup` for more info
     pub unsafe fn read_for_cleanup(index: &'a PgRelation, block: BlockNumber) -> Self {
-        let fork_number = ForkNumber_MAIN_FORKNUM;
+        let fork_number = ForkNumber::MAIN_FORKNUM;
 
         let buf = pg_sys::ReadBufferExtended(
             index.as_ptr(),
             fork_number,
             block,
-            ReadBufferMode_RBM_NORMAL,
+            ReadBufferMode::RBM_NORMAL,
             std::ptr::null_mut(),
         );
 
@@ -153,14 +152,14 @@ impl<'a> LockedBufferShare<'a> {
     ///
     /// Safety: Safe because it checks the block number doesn't overflow. ReadBufferExtended will throw an error if the block number is out of range for the relation
     pub fn read(index: &'a PgRelation, block: BlockNumber) -> Self {
-        let fork_number = ForkNumber_MAIN_FORKNUM;
+        let fork_number = ForkNumber::MAIN_FORKNUM;
 
         unsafe {
             let buf = pg_sys::ReadBufferExtended(
                 index.as_ptr(),
                 fork_number,
                 block,
-                ReadBufferMode_RBM_NORMAL,
+                ReadBufferMode::RBM_NORMAL,
                 std::ptr::null_mut(),
             );
 
@@ -210,14 +209,14 @@ impl PinnedBufferShare {
     ///
     /// Safety: Safe because it checks the block number doesn't overflow. ReadBufferExtended will throw an error if the block number is out of range for the relation
     pub fn read(index: &PgRelation, block: BlockNumber) -> Self {
-        let fork_number = ForkNumber_MAIN_FORKNUM;
+        let fork_number = ForkNumber::MAIN_FORKNUM;
 
         unsafe {
             let buf = pg_sys::ReadBufferExtended(
                 index.as_ptr(),
                 fork_number,
                 block,
-                ReadBufferMode_RBM_NORMAL,
+                ReadBufferMode::RBM_NORMAL,
                 std::ptr::null_mut(),
             );
             PinnedBufferShare { buffer: buf }

--- a/pgvectorscale/src/util/mod.rs
+++ b/pgvectorscale/src/util/mod.rs
@@ -96,13 +96,13 @@ impl ItemPointer {
     }
 
     pub unsafe fn with_item_pointer_data(ctid: pgrx::pg_sys::ItemPointerData) -> Self {
-        let ip = pgrx::item_pointer_get_block_number(&ctid);
-        let off = pgrx::item_pointer_get_offset_number(&ctid);
+        let ip = pgrx::itemptr::item_pointer_get_block_number(&ctid);
+        let off = pgrx::itemptr::item_pointer_get_offset_number(&ctid);
         Self::new(ip, off)
     }
 
     pub fn to_item_pointer_data(&self, ctid: &mut pgrx::pg_sys::ItemPointerData) {
-        pgrx::item_pointer_set_all(ctid, self.block_number, self.offset)
+        pgrx::itemptr::item_pointer_set_all(ctid, self.block_number, self.offset)
     }
 
     pub unsafe fn read_bytes(self, index: &PgRelation) -> ReadableBuffer {


### PR DESCRIPTION
Updates the pgrx version to the latest version, 0.12.5. This will let us add PG17 support next.

~~This has merge conflicts with https://github.com/timescale/pgvectorscale/pull/94 so it should be merged after it.~~