### PR TITLE
Add PG17 support

### DIFF
--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -23,6 +23,8 @@ jobs:
             minor: 7
           - major: 16
             minor: 3
+          - major: 17
+            minor: 0
         platform:
           - type: amd64
             runs_on: ubuntu-latest

--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -21,6 +21,8 @@ jobs:
             minor: 7
           - major: 16
             minor: 3
+          - major: 17
+            minor: 0
         platform:
           - type: amd64
             runs_on: ubuntu-latest

--- a/pgvectorscale/Cargo.toml
+++ b/pgvectorscale/Cargo.toml
@@ -16,6 +16,7 @@ pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
 pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg_test = []
 
 [dependencies]

--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -90,7 +90,7 @@ pub extern "C" fn ambuild(
     result.into_pg()
 }
 
-#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16"))]
+#[cfg(any(feature = "pg14", feature = "pg15", feature = "pg16", feature = "pg17"))]
 #[pg_guard]
 pub unsafe extern "C" fn aminsert(
     indexrel: pg_sys::Relation,


### PR DESCRIPTION
Adds support for PG17. Upgrading pgrx got us 90% of the way there, this PR just enables PG17.

I didn't change the default Postgres feature from PG16.