### PR TITLE
Fixes to nodes at distance 0

### DIFF
--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -864,11 +864,7 @@ pub mod tests {
         Ok(())
     }
 
-    pub fn verify_index_accuracy(
-        index_options: &str,
-        expected_cnt: i64,
-        dimensions: usize,
-    ) -> spi::Result<()> {
+    pub fn verify_index_accuracy(expected_cnt: i64, dimensions: usize) -> spi::Result<()> {
         let test_vec: Option<Vec<f32>> = Spi::get_one(&format!(
             "SELECT('{{' || array_to_string(array_agg(1.0), ',', '0') || '}}')::real[] AS embedding
     FROM generate_series(1, {dimensions})"
@@ -966,7 +962,8 @@ pub mod tests {
                         ('[' || array_to_string(array_agg(random()), ',', '0') || ']')::vector AS embedding
             FROM generate_series(1, {dimensions}));"))?;
 
-        verify_index_accuracy(index_options, expected_cnt, dimensions)
+        verify_index_accuracy(expected_cnt, dimensions)?;
+        Ok(())
     }
 
     #[pg_test]
@@ -1012,7 +1009,7 @@ pub mod tests {
                         ('[' || array_to_string(array_agg(random()), ',', '0') || ']')::vector AS embedding
             FROM generate_series(1, {dimensions}));"))?;
 
-        verify_index_accuracy(index_options, expected_cnt, dimensions)?;
+        verify_index_accuracy(expected_cnt, dimensions)?;
         Ok(())
     }
 }

--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -886,7 +886,7 @@ pub mod tests {
             )?;
 
         if cnt.unwrap() != expected_cnt {
-            /* better debugging */
+            // better debugging
             let id: Option<String> = Spi::get_one_with_args(
                 &format!(
                     "
@@ -920,9 +920,9 @@ pub mod tests {
 
     #[pg_test]
     pub unsafe fn test_index_small_accuracy() -> spi::Result<()> {
-        /* Test for the creation of connected graphs when the number of dimensions is small as is the
-        number of neighborss */
-        /* small num_neighbors is especially challenging for making sure no nodes get disconnected */
+        // Test for the creation of connected graphs when the number of dimensions is small as is the
+        // number of neighborss
+        // small num_neighbors is especially challenging for making sure no nodes get disconnected
         let index_options = "num_neighbors=10, search_list_size=10";
         let expected_cnt = 1000;
         let dimensions = 2;
@@ -968,9 +968,9 @@ pub mod tests {
 
     #[pg_test]
     pub unsafe fn test_index_small_accuracy_insert_after_index_created() -> spi::Result<()> {
-        /* Test for the creation of connected graphs when the number of dimensions is small as is the
-        number of neighborss */
-        /* small num_neighbors is especially challenging for making sure no nodes get disconnected */
+        // Test for the creation of connected graphs when the number of dimensions is small as is the
+        // number of neighborss
+        // small num_neighbors is especially challenging for making sure no nodes get disconnected
         let index_options = "num_neighbors=10, search_list_size=10";
         let expected_cnt = 1000;
         let dimensions = 2;

--- a/pgvectorscale/src/access_method/graph.rs
+++ b/pgvectorscale/src/access_method/graph.rs
@@ -264,6 +264,7 @@ impl<'a> Graph<'a> {
     ///
     /// Note this is the one-shot implementation that keeps only the closest `search_list_size` results in
     /// the returned ListSearchResult elements. It shouldn't be used with self.greedy_search_iterate
+    #[allow(clippy::mutable_key_type)]
     fn greedy_search_for_build<S: Storage>(
         &self,
         index_pointer: IndexPointer,
@@ -463,6 +464,7 @@ impl<'a> Graph<'a> {
         let meta_page = self.get_meta_page();
 
         //TODO: make configurable?
+        #[allow(clippy::mutable_key_type)]
         let v = self.greedy_search_for_build(
             index_pointer,
             vec,
@@ -490,7 +492,7 @@ impl<'a> Graph<'a> {
                 &mut stats.prune_neighbor_stats,
             );
             if contains {
-                cnt_contains = cnt_contains + 1;
+                cnt_contains += 1;
             }
         }
         if neighbor_list_len > 0 && cnt_contains == 0 {

--- a/pgvectorscale/src/access_method/neighbor_with_distance.rs
+++ b/pgvectorscale/src/access_method/neighbor_with_distance.rs
@@ -30,6 +30,7 @@ impl DistanceWithTieBreak {
         //this is the distance from the query to a index node.
         //make the distance_tie_break = 0
         let distance_tie_break = OnceCell::new();
+        //explicitly set the distance_tie_break to 0 to avoid the cost of computing it
         distance_tie_break.set(0).unwrap();
         DistanceWithTieBreak {
             distance,
@@ -47,6 +48,18 @@ impl DistanceWithTieBreak {
 
     pub fn get_distance(&self) -> Distance {
         self.distance
+    }
+
+    pub fn get_factor(&self, divisor: &Self) -> f64 {
+        if divisor.get_distance() < 0.0 + f32::EPSILON {
+            if self.get_distance() < 0.0 + f32::EPSILON {
+                self.get_distance_tie_break() as f64 / divisor.get_distance_tie_break() as f64
+            } else {
+                f64::MAX
+            }
+        } else {
+            self.get_distance() as f64 / divisor.get_distance() as f64
+        }
     }
 }
 

--- a/pgvectorscale/src/access_method/neighbor_with_distance.rs
+++ b/pgvectorscale/src/access_method/neighbor_with_distance.rs
@@ -65,18 +65,18 @@ impl DistanceWithTieBreak {
 
 impl PartialOrd for DistanceWithTieBreak {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        if self.distance == 0.0 && other.distance == 0.0 {
-            return self
-                .get_distance_tie_break()
-                .partial_cmp(&other.get_distance_tie_break());
-        }
-        self.distance.partial_cmp(&other.distance)
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for DistanceWithTieBreak {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        if self.distance == 0.0 && other.distance == 0.0 {
+            return self
+                .get_distance_tie_break()
+                .cmp(&other.get_distance_tie_break());
+        }
+        self.distance.total_cmp(&other.distance)
     }
 }
 

--- a/pgvectorscale/src/access_method/neighbor_with_distance.rs
+++ b/pgvectorscale/src/access_method/neighbor_with_distance.rs
@@ -1,39 +1,104 @@
-use std::cmp::Ordering;
+use std::{cell::OnceCell, cmp::Ordering};
 
 use crate::util::{IndexPointer, ItemPointer};
 
 //TODO is this right?
 pub type Distance = f32;
+
+/* implements a distance with a lazy tie break */
+#[derive(Clone, Debug)]
+pub struct DistanceWithTieBreak {
+    distance: Distance,
+    from: IndexPointer,
+    to: IndexPointer,
+    _distance_tie_break: OnceCell<usize>,
+}
+
+impl DistanceWithTieBreak {
+    pub fn new(distance: Distance, from: IndexPointer, to: IndexPointer) -> Self {
+        assert!(!distance.is_nan());
+        assert!(distance >= 0.0);
+        DistanceWithTieBreak {
+            distance,
+            from,
+            to,
+            _distance_tie_break: OnceCell::new(),
+        }
+    }
+
+    pub fn with_query(distance: Distance, to: IndexPointer) -> Self {
+        //this is the distance from the query to a index node.
+        //make the distance_tie_break = 0
+        let distance_tie_break = OnceCell::new();
+        distance_tie_break.set(0).unwrap();
+        DistanceWithTieBreak {
+            distance,
+            from: to,
+            to,
+            _distance_tie_break: distance_tie_break,
+        }
+    }
+
+    pub fn get_distance_tie_break(&self) -> usize {
+        *self
+            ._distance_tie_break
+            .get_or_init(|| self.from.ip_distance(self.to))
+    }
+
+    pub fn get_distance(&self) -> Distance {
+        self.distance
+    }
+}
+
+impl PartialOrd for DistanceWithTieBreak {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self.distance == 0.0 && other.distance == 0.0 {
+            return self
+                .get_distance_tie_break()
+                .partial_cmp(&other.get_distance_tie_break());
+        }
+        self.distance.partial_cmp(&other.distance)
+    }
+}
+
+impl Ord for DistanceWithTieBreak {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PartialEq for DistanceWithTieBreak {
+    fn eq(&self, other: &Self) -> bool {
+        if self.distance == 0.0 && other.distance == 0.0 {
+            return self.get_distance_tie_break() == other.get_distance_tie_break();
+        }
+        self.distance == other.distance
+    }
+}
+
+//promise that PartialEq is reflexive
+impl Eq for DistanceWithTieBreak {}
+
 #[derive(Clone, Debug)]
 pub struct NeighborWithDistance {
     index_pointer: IndexPointer,
-    distance: Distance,
-    distance_tie_break: usize,
+    distance: DistanceWithTieBreak,
 }
 
 impl NeighborWithDistance {
-    pub fn new(
-        neighbor_index_pointer: ItemPointer,
-        distance: Distance,
-        distance_tie_break: usize,
-    ) -> Self {
-        assert!(!distance.is_nan());
-        assert!(distance >= 0.0);
+    pub fn new(neighbor_index_pointer: ItemPointer, distance: DistanceWithTieBreak) -> Self {
         Self {
             index_pointer: neighbor_index_pointer,
             distance,
-            distance_tie_break,
         }
     }
 
     pub fn get_index_pointer_to_neighbor(&self) -> ItemPointer {
         self.index_pointer
     }
-    pub fn get_distance(&self) -> Distance {
-        self.distance
-    }
-    pub fn get_distance_tie_break(&self) -> usize {
-        return self.distance_tie_break;
+
+    pub fn get_distance_with_tie_break(&self) -> &DistanceWithTieBreak {
+        &self.distance
     }
 }
 
@@ -45,10 +110,7 @@ impl PartialOrd for NeighborWithDistance {
 
 impl Ord for NeighborWithDistance {
     fn cmp(&self, other: &Self) -> Ordering {
-        if self.distance == 0.0 && other.distance == 0.0 {
-            return self.distance_tie_break.cmp(&other.distance_tie_break);
-        }
-        self.distance.total_cmp(&other.distance)
+        self.distance.cmp(&other.distance)
     }
 }
 

--- a/pgvectorscale/src/access_method/neighbor_with_distance.rs
+++ b/pgvectorscale/src/access_method/neighbor_with_distance.rs
@@ -8,15 +8,21 @@ pub type Distance = f32;
 pub struct NeighborWithDistance {
     index_pointer: IndexPointer,
     distance: Distance,
+    distance_tie_break: usize,
 }
 
 impl NeighborWithDistance {
-    pub fn new(neighbor_index_pointer: ItemPointer, distance: Distance) -> Self {
+    pub fn new(
+        neighbor_index_pointer: ItemPointer,
+        distance: Distance,
+        distance_tie_break: usize,
+    ) -> Self {
         assert!(!distance.is_nan());
         assert!(distance >= 0.0);
         Self {
             index_pointer: neighbor_index_pointer,
             distance,
+            distance_tie_break,
         }
     }
 
@@ -25,6 +31,9 @@ impl NeighborWithDistance {
     }
     pub fn get_distance(&self) -> Distance {
         self.distance
+    }
+    pub fn get_distance_tie_break(&self) -> usize {
+        return self.distance_tie_break;
     }
 }
 
@@ -36,6 +45,9 @@ impl PartialOrd for NeighborWithDistance {
 
 impl Ord for NeighborWithDistance {
     fn cmp(&self, other: &Self) -> Ordering {
+        if self.distance == 0.0 && other.distance == 0.0 {
+            return self.distance_tie_break.cmp(&other.distance_tie_break);
+        }
         self.distance.total_cmp(&other.distance)
     }
 }

--- a/pgvectorscale/src/access_method/neighbor_with_distance.rs
+++ b/pgvectorscale/src/access_method/neighbor_with_distance.rs
@@ -5,13 +5,13 @@ use crate::util::{IndexPointer, ItemPointer};
 //TODO is this right?
 pub type Distance = f32;
 
-/* implements a distance with a lazy tie break */
+// implements a distance with a lazy tie break
 #[derive(Clone, Debug)]
 pub struct DistanceWithTieBreak {
     distance: Distance,
     from: IndexPointer,
     to: IndexPointer,
-    _distance_tie_break: OnceCell<usize>,
+    distance_tie_break: OnceCell<usize>,
 }
 
 impl DistanceWithTieBreak {
@@ -22,7 +22,7 @@ impl DistanceWithTieBreak {
             distance,
             from,
             to,
-            _distance_tie_break: OnceCell::new(),
+            distance_tie_break: OnceCell::new(),
         }
     }
 
@@ -36,17 +36,17 @@ impl DistanceWithTieBreak {
             distance,
             from: to,
             to,
-            _distance_tie_break: distance_tie_break,
+            distance_tie_break,
         }
     }
 
-    pub fn get_distance_tie_break(&self) -> usize {
+    fn get_distance_tie_break(&self) -> usize {
         *self
-            ._distance_tie_break
+            .distance_tie_break
             .get_or_init(|| self.from.ip_distance(self.to))
     }
 
-    pub fn get_distance(&self) -> Distance {
+    fn get_distance(&self) -> Distance {
         self.distance
     }
 

--- a/pgvectorscale/src/access_method/plain_storage.rs
+++ b/pgvectorscale/src/access_method/plain_storage.rs
@@ -2,6 +2,7 @@ use super::{
     distance::DistanceFn,
     graph::{ListSearchNeighbor, ListSearchResult},
     graph_neighbor_store::GraphNeighborStore,
+    neighbor_with_distance::DistanceWithTieBreak,
     pg_vector::PgVector,
     plain_node::{ArchivedNode, Node, ReadableNode},
     stats::{
@@ -256,8 +257,7 @@ impl<'a> Storage for PlainStorage<'a> {
             let dist = unsafe { dist_state.get_distance(n, stats) };
             result.push(NeighborWithDistance::new(
                 n,
-                dist,
-                n.ip_distance(neighbors_of),
+                DistanceWithTieBreak::new(dist, neighbors_of, n),
             ))
         }
     }
@@ -288,7 +288,7 @@ impl<'a> Storage for PlainStorage<'a> {
 
         ListSearchNeighbor::new(
             index_pointer,
-            distance,
+            lsr.create_distance_with_tie_break(distance, index_pointer),
             PlainStorageLsnPrivateData::new(index_pointer, node, gns),
         )
     }
@@ -322,7 +322,7 @@ impl<'a> Storage for PlainStorage<'a> {
             };
             let lsn = ListSearchNeighbor::new(
                 neighbor_index_pointer,
-                distance,
+                lsr.create_distance_with_tie_break(distance, neighbor_index_pointer),
                 PlainStorageLsnPrivateData::new(neighbor_index_pointer, node_neighbor, gns),
             );
 

--- a/pgvectorscale/src/access_method/plain_storage.rs
+++ b/pgvectorscale/src/access_method/plain_storage.rs
@@ -254,7 +254,11 @@ impl<'a> Storage for PlainStorage<'a> {
         let dist_state = unsafe { IndexFullDistanceMeasure::with_readable_node(self, rn) };
         for n in neighbors {
             let dist = unsafe { dist_state.get_distance(n, stats) };
-            result.push(NeighborWithDistance::new(n, dist))
+            result.push(NeighborWithDistance::new(
+                n,
+                dist,
+                n.ip_distance(neighbors_of),
+            ))
         }
     }
 

--- a/pgvectorscale/src/access_method/sbq.rs
+++ b/pgvectorscale/src/access_method/sbq.rs
@@ -2,6 +2,7 @@ use super::{
     distance::{distance_xor_optimized, DistanceFn},
     graph::{ListSearchNeighbor, ListSearchResult},
     graph_neighbor_store::GraphNeighborStore,
+    neighbor_with_distance::DistanceWithTieBreak,
     pg_vector::PgVector,
     stats::{
         GreedySearchStats, StatsDistanceComparison, StatsHeapNodeRead, StatsNodeModify,
@@ -516,7 +517,7 @@ impl<'a> SbqSpeedupStorage<'a> {
 
                     let lsn = ListSearchNeighbor::new(
                         neighbor_index_pointer,
-                        distance,
+                        lsr.create_distance_with_tie_break(distance, neighbor_index_pointer),
                         PhantomData::<bool>,
                     );
 
@@ -539,7 +540,7 @@ impl<'a> SbqSpeedupStorage<'a> {
 
                     let lsn = ListSearchNeighbor::new(
                         neighbor_index_pointer,
-                        distance,
+                        lsr.create_distance_with_tie_break(distance, neighbor_index_pointer),
                         PhantomData::<bool>,
                     );
 
@@ -674,9 +675,7 @@ impl<'a> Storage for SbqSpeedupStorage<'a> {
             let dist = distance_xor_optimized(q, rn1.get_archived_node().bq_vector.as_slice());
             result.push(NeighborWithDistance::new(
                 n,
-                dist as f32,
-                //OPT: probably should make this calculation lazy
-                n.ip_distance(neighbors_of),
+                DistanceWithTieBreak::new(dist as f32, neighbors_of, n),
             ))
         }
     }
@@ -702,7 +701,11 @@ impl<'a> Storage for SbqSpeedupStorage<'a> {
             &mut lsr.stats,
         );
 
-        ListSearchNeighbor::new(index_pointer, distance, PhantomData::<bool>)
+        ListSearchNeighbor::new(
+            index_pointer,
+            lsr.create_distance_with_tie_break(distance, index_pointer),
+            PhantomData::<bool>,
+        )
     }
 
     fn visit_lsn(

--- a/pgvectorscale/src/access_method/sbq.rs
+++ b/pgvectorscale/src/access_method/sbq.rs
@@ -672,7 +672,12 @@ impl<'a> Storage for SbqSpeedupStorage<'a> {
             let rn1 = unsafe { SbqNode::read(self.index, n, stats) };
             stats.record_quantized_distance_comparison();
             let dist = distance_xor_optimized(q, rn1.get_archived_node().bq_vector.as_slice());
-            result.push(NeighborWithDistance::new(n, dist as f32))
+            result.push(NeighborWithDistance::new(
+                n,
+                dist as f32,
+                //OPT: probably should make this calculation lazy
+                n.ip_distance(neighbors_of),
+            ))
         }
     }
 

--- a/pgvectorscale/src/util/mod.rs
+++ b/pgvectorscale/src/util/mod.rs
@@ -123,13 +123,10 @@ impl ItemPointer {
     }
 
     pub fn ip_distance(self, other: Self) -> usize {
-        /* distance measure based on on-disk distance */
-        /* The two abs() give better results than taking one abs() at the end. Not quite sure why but I think
-         * It creates more links within the equivalence class  */
-        let block_diff = (self.block_number as isize - other.block_number as isize).unsigned_abs();
-        let offset_diff = (self.offset as isize - other.offset as isize).unsigned_abs();
+        let block_diff = self.block_number as isize - other.block_number as isize;
+        let offset_diff = self.offset as isize - other.offset as isize;
         debug_assert!(offset_diff < pgrx::pg_sys::MaxOffsetNumber as _);
-        block_diff * (pgrx::pg_sys::MaxOffsetNumber as usize) + offset_diff
+        (block_diff * (pgrx::pg_sys::MaxOffsetNumber as isize) + offset_diff).unsigned_abs()
     }
 }
 


### PR DESCRIPTION
This PR fixes several issues with the previous way of handling nodes at distance 0.
1) the tie break logic wasn't applied everywhere it needed to be in a consistent way. Critically, the initial sorting in the prune procedure didn't sort correctly. This was fixed by adjusting the  NeighborWithDistance class.
2) after (1) was fixed, it turns out we could adjust the distance function to be the standard, expected one. Which we do.

The first commit fixes all the bugs.
Subsequent commits refactor the code to avoid similar bugs in the future by encapsulating the distance logic in the DistanceWithTieBreak struct.