### PR TITLE
Add upgrade tests from all released versions

### DIFF
--- a/pgvectorscale/src/access_method/upgrade_test.rs
+++ b/pgvectorscale/src/access_method/upgrade_test.rs
@@ -205,6 +205,7 @@ pub mod tests {
         assert_eq!(cnt, 303, "count after upgrade");
     }
 
+    #[ignore]
     #[test]
     fn test_upgrade_from_0_0_2() {
         test_upgrade_base(
@@ -216,16 +217,19 @@ pub mod tests {
         );
     }
 
+    #[ignore]
     #[test]
     fn test_upgrade_from_0_2_0() {
         test_upgrade_base("0.2.0", "0.11.4", "pgvectorscale", "vectorscale", "diskann");
     }
 
+    #[ignore]
     #[test]
     fn test_upgrade_from_0_3_0() {
         test_upgrade_base("0.3.0", "0.11.4", "pgvectorscale", "vectorscale", "diskann");
     }
 
+    #[ignore]
     #[test]
     fn test_upgrade_from_0_4_0() {
         test_upgrade_base("0.4.0", "0.12.5", "pgvectorscale", "vectorscale", "diskann");


### PR DESCRIPTION
The current upgrade test exercises only the 0.0.2 -> current upgrade path.  This PR adds cases for the other released versions (0.2.0, 0.3.0, 0.4.0).  Will mark these tests as `#[ignore]` before merging.