### PR TITLE
Fit and finish before 0.5.0 release PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can install pgvectorscale from source and install it in an existing PostgreS
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     ## pgrx
     cargo install --locked cargo-pgrx
-    cargo pgrx init --pg16 pg_config
+    cargo pgrx init --pg17 pg_config
 
     #download, build and install pgvectorscale
     cd /tmp
@@ -155,7 +155,7 @@ To enable pgvectorscale:
 1. Create a StreamingDiskANN index on the embedding column:
     ```postgresql
     CREATE INDEX document_embedding_idx ON document_embedding
-    USING diskann (embedding);
+    USING diskann (embedding vector_cosine_ops);
     ```
 1. Find the 10 closest embeddings using the index.
 
@@ -166,12 +166,12 @@ To enable pgvectorscale:
     LIMIT 10
     ```
 
-    Note: pgvectorscale currently support cosine distance (`<=>`) queries. If you would like additional distance types,
+    Note: pgvectorscale currently supports: cosine distance (`<=>`) queries, for indices created with `vector_cosine_ops`; and L2 distance (`<->`) queries, for indices created with `vector_l2_ops`.  This is the same syntax used by `pgvector`.  If you would like additional distance types,
     [create an issue](https://github.com/timescale/pgvectorscale/issues).
 
 ## Tuning
 
-The StreamingDiskANN index comes with **smart defaults** but also the ability to customize it's behavior. There are two types of parameters: index build-time parameters that are specified when an index is created and query-time parameters that can be tuned when querying an index.
+The StreamingDiskANN index comes with **smart defaults** but also the ability to customize its behavior. There are two types of parameters: index build-time parameters that are specified when an index is created and query-time parameters that can be tuned when querying an index.
 
 We suggest setting the index build-time paramers for major changes to index operations while query-time parameters can be used to tune the accuracy/performance tradeoff for individual queries.
 

--- a/pgvectorscale/Cargo.toml
+++ b/pgvectorscale/Cargo.toml
@@ -27,6 +27,7 @@ simdeez = { version = "1.0.8" }
 rand = { version = "0.8", features = ["small_rng"] }
 pgvectorscale_derive = { path = "pgvectorscale_derive" }
 semver = "1.0.22"
+serial_test = "3.2.0"
 once_cell = "1.20.1"
 
 [dev-dependencies]

--- a/pgvectorscale/src/access_method/upgrade_test.rs
+++ b/pgvectorscale/src/access_method/upgrade_test.rs
@@ -2,6 +2,7 @@
 #[pgrx::pg_schema]
 pub mod tests {
     use pgrx::*;
+    use serial_test::serial;
     use std::{fs, path::Path, process::Stdio};
 
     fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
@@ -28,8 +29,8 @@ pub mod tests {
         extname: &str,
         amname: &str,
     ) {
-        if cfg!(feature = "pg17") {
-            // PG17 is only supported for one version
+        if cfg!(feature = "pg17") && version != "0.4.0" {
+            // PG17 was not supported before 0.4.0
             return;
         }
         pgrx_tests::run_test(
@@ -224,6 +225,7 @@ pub mod tests {
     }
 
     #[ignore]
+    #[serial]
     #[test]
     fn test_upgrade_from_0_0_2() {
         test_upgrade_base(
@@ -236,18 +238,21 @@ pub mod tests {
     }
 
     #[ignore]
+    #[serial]
     #[test]
     fn test_upgrade_from_0_2_0() {
         test_upgrade_base("0.2.0", "0.11.4", "pgvectorscale", "vectorscale", "diskann");
     }
 
     #[ignore]
+    #[serial]
     #[test]
     fn test_upgrade_from_0_3_0() {
         test_upgrade_base("0.3.0", "0.11.4", "pgvectorscale", "vectorscale", "diskann");
     }
 
     #[ignore]
+    #[serial]
     #[test]
     fn test_upgrade_from_0_4_0() {
         test_upgrade_base("0.4.0", "0.12.5", "pgvectorscale", "vectorscale", "diskann");


### PR DESCRIPTION
Just to keep the actual deployment PR simpler, some fit and finish changes:
* Updated README.md to cover L2 distance support
* Tweaks to upgrade tests to (a) account for the possibility of upgrade from 0.4.0 on pg17, and (b) mark upgrade tests as serial to get us closer to allow running them all in one go.  There is still an issue with pgrx dropping the test schema that needs to be fixed to get this actually working, but we can deal with that later.