### PR TITLE
Bump version number for 0.5.0 postrelease

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,13 @@
+[workspace]
+members = ["pgvectorscale"]
+resolver = "2"
+
+[profile.dev]
+panic = "unwind"
+
+[profile.release]
+panic = "unwind"
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+#debug = true

--- a/pgvectorscale/Cargo.toml
+++ b/pgvectorscale/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorscale"
-version = "0.5.0"
+version = "0.6.0-dev"
 edition = "2021"
 
 [lib]
@@ -35,16 +35,6 @@ pgrx-tests = "=0.12.5"
 pgrx-pg-config = "=0.12.5"
 criterion = "0.5.1"
 tempfile = "3.3.0"
-
-[profile.dev]
-panic = "unwind"
-
-[profile.release]
-panic = "unwind"
-opt-level = 3
-lto = "fat"
-codegen-units = 1
-#debug = true
 
 [[bench]]
 name = "distance"


### PR DESCRIPTION
This PR bumps the cargo version number to 0.6.0-dev, now that we've released 0.5.0.  I also added a top-level Cargo.toml file to allow cargo operations from the root directory, as we do in the toolkit project.