### PR TITLE
Only normalize vectors if index uses cosine distance

### DIFF
--- a/pgvectorscale/src/access_method/meta_page.rs
+++ b/pgvectorscale/src/access_method/meta_page.rs
@@ -162,6 +162,10 @@ impl MetaPage {
         DistanceType::from_u16(self.distance_type).get_distance_function()
     }
 
+    pub fn get_distance_type(&self) -> DistanceType {
+        DistanceType::from_u16(self.distance_type)
+    }
+
     pub fn get_storage_type(&self) -> StorageType {
         StorageType::from_u8(self.storage_type)
     }

--- a/pgvectorscale/src/access_method/pg_vector.rs
+++ b/pgvectorscale/src/access_method/pg_vector.rs
@@ -1,5 +1,7 @@
 use pgrx::*;
 
+use crate::access_method::distance::DistanceType;
+
 use super::{distance::preprocess_cosine, meta_page};
 
 //Ported from pg_vector code
@@ -99,7 +101,9 @@ impl PgVector {
         let dim = (*casted).dim;
         let raw_slice = unsafe { (*casted).x.as_mut_slice(dim as _) };
 
-        preprocess_cosine(raw_slice);
+        if meta_page.get_distance_type() == DistanceType::Cosine {
+            preprocess_cosine(raw_slice);
+        }
         casted
     }
 


### PR DESCRIPTION
## Description

Cosine vector indices benefit from pre-normalization of vectors when added to index, and one-time normalization of the query vector, so that distance computation reduces to a simple inner product.  L2 and other metrics, however, are sensitive to vector magnitudes, so we should not normalize in that case.

## Testing

Added a unit test that fails without my fix.