### PR TITLE
Mark distance_type_* as CREATE OR REPLACE

### DIFF
--- a/pgvectorscale/src/access_method/distance.rs
+++ b/pgvectorscale/src/access_method/distance.rs
@@ -39,12 +39,12 @@ impl DistanceType {
     }
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, create_or_replace)]
 pub fn distance_type_cosine() -> i16 {
     DistanceType::Cosine as i16
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, create_or_replace)]
 pub fn distance_type_l2() -> i16 {
     DistanceType::L2 as i16
 }


### PR DESCRIPTION
`distance_type_*` needs to be marked as `create_or_replace` so that the pgrx schema generator generates update scripts with `CREATE OR REPLACE`. Without `OR REPLACE` upgrading fails.