### PR TITLE
Find repo root properly when upgrade testing in a Cargo workspace

### DIFF
--- a/pgvectorscale/src/access_method/upgrade_test.rs
+++ b/pgvectorscale/src/access_method/upgrade_test.rs
@@ -53,8 +53,14 @@ pub mod tests {
 
         // Convert the file path to an absolute path
         let current_dir = std::env::current_dir().unwrap();
-        let mut absolute_path = std::path::Path::new(&current_dir).join(current_file);
-        absolute_path = absolute_path.ancestors().nth(4).unwrap().to_path_buf();
+        let absolute_path_full = std::path::Path::new(&current_dir).join(current_file);
+        let mut absolute_path = None;
+        for ancestor in absolute_path_full.ancestors() {
+            if std::fs::exists(ancestor.join(".git")).unwrap() {
+                absolute_path = Some(ancestor.to_path_buf());
+            }
+        }
+        let absolute_path = absolute_path.expect("Couldn't find root directory");
 
         let temp_dir = tempfile::tempdir().unwrap();
         let temp_path = temp_dir.path();


### PR DESCRIPTION
Previously, the logic in the upgrade tester assumed that the path to the repo root was 4 levels up from the executable. This PR makes it look for the first parent directory with a `.git` subdirectory, so it works regardless of where the target directory is.