### PR TITLE
Properly check if PG17 is supported in upgrade tester

### DIFF
--- a/pgvectorscale/src/access_method/upgrade_test.rs
+++ b/pgvectorscale/src/access_method/upgrade_test.rs
@@ -29,7 +29,9 @@ pub mod tests {
         extname: &str,
         amname: &str,
     ) {
-        if cfg!(feature = "pg17") && version != "0.4.0" {
+        if cfg!(feature = "pg17")
+            && semver::Version::parse(version).unwrap() < semver::Version::parse("0.4.0").unwrap()
+        {
             // PG17 was not supported before 0.4.0
             return;
         }


### PR DESCRIPTION
This fixes the upgrade tester to properly check if the version can be tested in PG17. It checks if the version is less than 0.4.0 using `semver::Version` instead of a direct string comparision.