### PR TITLE
Use workspace target directory location in Debian install file

### DIFF
--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -61,8 +61,8 @@ Depends: postgresql-$pg
 Description: pgvectorscale for speeding up ANN search
 EOF
 
-    echo "target/release/vectorscale-pg$pg/$libdir/* usr/lib/postgresql/$pg/lib/" >"${BASEDIR}"/debian/pgvectorscale-postgresql-"$pg".install
-    echo "target/release/vectorscale-pg$pg/$sharedir/* usr/share/postgresql/$pg/" >>"${BASEDIR}"/debian/pgvectorscale-postgresql-"$pg".install
+    echo "../target/release/vectorscale-pg$pg/$libdir/* usr/lib/postgresql/$pg/lib/" >"${BASEDIR}"/debian/pgvectorscale-postgresql-"$pg".install
+    echo "../target/release/vectorscale-pg$pg/$sharedir/* usr/share/postgresql/$pg/" >>"${BASEDIR}"/debian/pgvectorscale-postgresql-"$pg".install
 done
 
 dpkg-buildpackage --build=binary --no-sign --post-clean


### PR DESCRIPTION
We changed this repo to be a Cargo workspace. To make Debian packages, we now need to look in a different path for the built binaries.