### PR TITLE
Fix CI - rely on ubuntu-22.04 as we used to

### DIFF
--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -25,7 +25,7 @@ jobs:
             minor: 0
         platform:
           - type: amd64
-            runs_on: ubuntu-latest
+            runs_on: ubuntu-22.04
             rustflags: '-C target-feature=+avx2,+fma'
           - type: arm64
             runs_on: cloud-image-runner-arm64


### PR DESCRIPTION
Starting on December, Github is relying on ubuntu-24.04 to be the default ubuntu-latest image.
Specify ubuntu-22.04 as our image of choice in the meantime, given that the new LLVM libs are
crashing in our CI install pgrx step.

More details on this [issue](https://github.com/actions/runner-images/issues/10636)