### PR TITLE
Have cargo-pgrx install command specify version

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ To create a pgvectorscale developer environment, you need the following on your 
   
 * [Cargo-pgrx][cargo-pgrx]:
     ```shell
-    cargo install --locked cargo-pgrx
+    cargo install --locked cargo-pgrx --version $(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "pgrx") | .version')
     ```
   You must reinstall cargo-pgrx whenever you update Rust, cargo-pgrx must 
   be built with the same compiler as pgvectorscale.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ You can install pgvectorscale from source and install it in an existing PostgreS
     # install prerequisites
     ## rust
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-    ## pgrx
-    cargo install --locked cargo-pgrx
+    ## cargo-pgrx with the same version as pgrx
+    cargo install --locked cargo-pgrx --version $(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "pgrx") | .version')
     cargo pgrx init --pg17 pg_config
 
     #download, build and install pgvectorscale


### PR DESCRIPTION
Right now if you run the command to install cargo-pgrx from the README or DEVELOPMENT file, it doesn't work because it tries to install the latest version, while we require an older patch version. This PR changes these files to have the installation command read the required cargo-pgrx version from the `Cargo.toml` file.

I didn't write the actual pgrx version (currently 0.12.5) in the file to avoid adding another thing that needs to be changed every pgrx version bump.