### PR TITLE
Automatically set AVX2/FMA flags on x86

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
 [target.'cfg(target_os="macos")']
 # Postgres symbols won't be available until runtime
 rustflags = ["-Clink-arg=-Wl,-undefined,dynamic_lookup"]
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))']
+rustflags = ["-Ctarget-feature=+avx2,+fma"]

--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -32,10 +32,8 @@ jobs:
         platform:
           - type: amd64
             runs_on: ubuntu-latest
-            rustflags: '-C target-feature=+avx2,+fma'
           - type: arm64
             runs_on: cloud-image-runner-arm64
-            rustflags: ''
 
     env:
       PG_SRC_DIR: pgbuild
@@ -81,7 +79,7 @@ jobs:
       id: debbuild
       run: |
         export PATH=~/${{ env.PG_INSTALL_DIR }}/bin:$PATH
-        (cd ${{ env.TAG_DIR }} &&  ${{ matrix.platform.rustflags != '' && format('RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }} make package)
+        (cd ${{ env.TAG_DIR }} && make package)
         bash scripts/package-deb.sh "${{ env.TAG }}" "${PWD}/${{ env.TAG_DIR }}" "$RUNNER_OS" "${{ matrix.pg.major }}"
 
   # Use a GH artifact, then we can make use of the (quite limited) GH API https://docs.github.com/en/rest/actions/artifacts

--- a/.github/workflows/pgrx_test.yaml
+++ b/.github/workflows/pgrx_test.yaml
@@ -26,10 +26,8 @@ jobs:
         platform:
           - type: amd64
             runs_on: ubuntu-22.04
-            rustflags: '-C target-feature=+avx2,+fma'
           - type: arm64
             runs_on: cloud-image-runner-arm64
-            rustflags: ''
 
     env:
       PG_SRC_DIR: pgbuild
@@ -70,12 +68,10 @@ jobs:
       id: clippy
       run: |
         cd pgvectorscale
-        ${{ matrix.platform.rustflags != '' && format('export RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }}
         cargo clippy --all-targets --no-default-features --features 'pg_test pg${{ matrix.pg.major }}'
 
     - name: Run tests
       id: runtests 
       run: |
         cd pgvectorscale
-        ${{ matrix.platform.rustflags != '' && format('export RUSTFLAGS="{0}"',  matrix.platform.rustflags) || '' }} 
         cargo pgrx test -- pg${{ matrix.pg.major }}


### PR DESCRIPTION
We can put the AVX2 and FMA flags in the `.cargo/config.toml` file so that they are automatically applied on x86, instead of users having to manually set an environment variable.