### PR TITLE
Cleanup and traits for nodes

### DIFF
--- a/pgvectorscale/src/access_method/debugging.rs
+++ b/pgvectorscale/src/access_method/debugging.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 
 use pgrx::PgRelation;
 
+use crate::access_method::node::ReadableNode;
 use crate::util::ItemPointer;
 
-use super::{plain_node::Node, stats::GreedySearchStats};
+use super::{plain_node::PlainNode, stats::GreedySearchStats};
 
 #[allow(dead_code)]
 pub fn print_graph_from_disk(index: &PgRelation, init_id: ItemPointer) {
@@ -25,7 +26,7 @@ unsafe fn print_graph_from_disk_visitor(
     sb: &mut String,
 ) {
     let mut stats = GreedySearchStats::new();
-    let data_node = Node::read(index, index_pointer, &mut stats);
+    let data_node = PlainNode::read(index, index_pointer, &mut stats);
     let node = data_node.get_archived_node();
     let v = node.vector.as_slice();
     let copy: Vec<f32> = v.to_vec();

--- a/pgvectorscale/src/access_method/meta_page.rs
+++ b/pgvectorscale/src/access_method/meta_page.rs
@@ -4,10 +4,6 @@ use pgvectorscale_derive::{Readable, Writeable};
 use rkyv::{Archive, Deserialize, Serialize};
 use semver::Version;
 
-use crate::access_method::options::TSVIndexOptions;
-use crate::util::page;
-use crate::util::*;
-
 use super::distance::{DistanceFn, DistanceType};
 use super::options::{
     NUM_DIMENSIONS_DEFAULT_SENTINEL, NUM_NEIGHBORS_DEFAULT_SENTINEL,
@@ -15,6 +11,10 @@ use super::options::{
 };
 use super::stats::StatsNodeModify;
 use super::storage::StorageType;
+use crate::access_method::node::{ReadableNode, WriteableNode};
+use crate::access_method::options::TSVIndexOptions;
+use crate::util::page;
+use crate::util::*;
 
 const TSV_MAGIC_NUMBER: u32 = 768756476; //Magic number, random
 const TSV_VERSION: u32 = 2;

--- a/pgvectorscale/src/access_method/mod.rs
+++ b/pgvectorscale/src/access_method/mod.rs
@@ -7,6 +7,7 @@ mod graph_neighbor_store;
 pub mod guc;
 mod meta_page;
 mod neighbor_with_distance;
+mod node;
 pub mod options;
 pub mod pg_vector;
 mod plain_node;

--- a/pgvectorscale/src/access_method/node.rs
+++ b/pgvectorscale/src/access_method/node.rs
@@ -1,0 +1,29 @@
+use pgrx::PgRelation;
+use rkyv::AlignedVec;
+
+use crate::util::{tape::Tape, ItemPointer};
+
+use super::stats::{StatsNodeModify, StatsNodeRead, StatsNodeWrite};
+
+pub trait ReadableNode {
+    type Node<'a>;
+    unsafe fn read<'a, S: StatsNodeRead>(
+        index: &'a PgRelation,
+        index_pointer: ItemPointer,
+        stats: &mut S,
+    ) -> Self::Node<'a>;
+}
+
+pub trait WriteableNode {
+    type Node<'a>;
+
+    unsafe fn modify<'a, S: StatsNodeModify>(
+        index: &'a PgRelation,
+        index_pointer: ItemPointer,
+        stats: &mut S,
+    ) -> Self::Node<'a>;
+
+    fn write<S: StatsNodeWrite>(&self, tape: &mut Tape, stats: &mut S) -> ItemPointer;
+
+    fn serialize_to_vec(&self) -> AlignedVec;
+}

--- a/pgvectorscale/src/access_method/plain_node.rs
+++ b/pgvectorscale/src/access_method/plain_node.rs
@@ -6,22 +6,22 @@ use pgvectorscale_derive::{Readable, Writeable};
 use rkyv::vec::ArchivedVec;
 use rkyv::{Archive, Deserialize, Serialize};
 
+use super::meta_page::MetaPage;
 use super::neighbor_with_distance::NeighborWithDistance;
 use super::storage::ArchivedData;
+use crate::access_method::node::{ReadableNode, WriteableNode};
 use crate::util::{ArchivedItemPointer, HeapPointer, ItemPointer, ReadableBuffer, WritableBuffer};
-
-use super::meta_page::MetaPage;
 
 #[derive(Archive, Deserialize, Serialize, Readable, Writeable)]
 #[archive(check_bytes)]
-pub struct Node {
+pub struct PlainNode {
     pub vector: Vec<f32>,
     pub pq_vector: Vec<u8>,
     neighbor_index_pointers: Vec<ItemPointer>,
     pub heap_item_pointer: HeapPointer,
 }
 
-impl Node {
+impl PlainNode {
     fn new_internal(
         vector: Vec<f32>,
         pq_vector: Vec<u8>,
@@ -52,7 +52,7 @@ impl Node {
 }
 
 /// contains helpers for mutate-in-place. See struct_mutable_refs in test_alloc.rs in rkyv
-impl ArchivedNode {
+impl ArchivedPlainNode {
     pub fn is_deleted(&self) -> bool {
         self.heap_item_pointer.offset == InvalidOffsetNumber
     }
@@ -106,9 +106,9 @@ impl ArchivedNode {
     }
 }
 
-impl ArchivedData for ArchivedNode {
-    fn with_data(data: &mut [u8]) -> Pin<&mut ArchivedNode> {
-        ArchivedNode::with_data(data)
+impl ArchivedData for ArchivedPlainNode {
+    fn with_data(data: &mut [u8]) -> Pin<&mut ArchivedPlainNode> {
+        ArchivedPlainNode::with_data(data)
     }
 
     fn get_index_pointer_to_neighbors(&self) -> Vec<ItemPointer> {

--- a/pgvectorscale/src/access_method/sbq.rs
+++ b/pgvectorscale/src/access_method/sbq.rs
@@ -17,6 +17,8 @@ use std::{cell::RefCell, collections::HashMap, iter::once, marker::PhantomData};
 use pgrx::{PgBox, PgRelation};
 use rkyv::{Archive, Deserialize, Serialize};
 
+use super::{meta_page::MetaPage, neighbor_with_distance::NeighborWithDistance};
+use crate::access_method::node::{ReadableNode, WriteableNode};
 use crate::util::{
     chain::{ChainItemReader, ChainTapeWriter},
     page::{PageType, ReadablePage},
@@ -24,8 +26,6 @@ use crate::util::{
     tape::Tape,
     HeapPointer, IndexPointer, ItemPointer, ReadableBuffer, WritableBuffer,
 };
-
-use super::{meta_page::MetaPage, neighbor_with_distance::NeighborWithDistance};
 use pgvectorscale_derive::{Readable, Writeable};
 
 pub type SbqVectorElement = u64;

--- a/pgvectorscale/src/access_method/sbq_node.rs
+++ b/pgvectorscale/src/access_method/sbq_node.rs
@@ -1,3 +1,4 @@
+use crate::access_method::node::{ReadableNode, WriteableNode};
 use crate::access_method::PgRelation;
 use crate::util::{ArchivedItemPointer, HeapPointer, ItemPointer, ReadableBuffer, WritableBuffer};
 use pgrx::pg_sys::{InvalidBlockNumber, InvalidOffsetNumber, BLCKSZ};


### PR DESCRIPTION
Refactoring tasks in preparation for the coming label-filtering PR:
* Split `SbqNode` functionality into separate file, since `sbq.rs` has way too much going on
* Introduce traits for node reading/writing to encapsulate functions emitted by proc macros (will be need in subsequent PR)
* Rename plain `Node` to `PlainNode`