### PR TITLE
Use LLVM 18 in GH Actions instead of 14

### DIFF
--- a/.github/actions/install-packages/action.yml
+++ b/.github/actions/install-packages/action.yml
@@ -6,5 +6,6 @@ runs:
       - name: Install Linux Dependencies
         shell: bash
         run: |
+          sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
           sudo apt-get update
-          sudo apt-get install -y flex bison lcov systemd-coredump gdb libblas-dev libipc-run-perl libtest-most-perl clang-14 llvm-14 llvm-14-dev llvm-14-runtime llvm-14-tools libopenblas-dev
+          sudo apt-get install -y flex bison lcov systemd-coredump gdb libblas-dev libipc-run-perl libtest-most-perl clang-18 llvm-18 llvm-18-dev llvm-18-runtime llvm-18-tools libopenblas-dev

--- a/.github/actions/install-pgrx/action.yml
+++ b/.github/actions/install-pgrx/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.cargo/bin/cargo-pgrx
-        key: ${{ runner.arch }}-${{runner.os}}-cargo-pgrx-${{ inputs.pgrx-version }}-pg${{ steps.pg-config.outputs.version }}-${{ steps.rustc.outputs.version }}
+        key: ${{ runner.arch }}-${{runner.os}}-cargo-pgrx-${{ inputs.pgrx-version }}-pg${{ steps.pg-config.outputs.version }}-${{ steps.rustc.outputs.version }}-v2
 
     - name: Install cargo-pgrx ${{ inputs.pgrx-version }}
       if: steps.cache-cargo-pgrx.outputs.cache-hit != 'true'

--- a/.github/actions/install-pgvector/action.yml
+++ b/.github/actions/install-pgvector/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       env:
         pg_build_args: --enable-debug --enable-cassert
-        llvm_config: llvm-config-14
+        llvm_config: llvm-config-18
         CC: gcc
         CXX: g++
       run: |

--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/cache@v4
       with:
        path: ${{ inputs.pg-src-dir }}
-       key: ${{ runner.arch }}-${{ runner.os }}-postgresql-${{ inputs.pg-version }}
+       key: ${{ runner.arch }}-${{ runner.os }}-postgresql-${{ inputs.pg-version }}-v2
 
     - name: Build PostgreSQL
       if: steps.cache-postgresql.outputs.cache-hit != 'true'

--- a/.github/actions/install-postgres/action.yml
+++ b/.github/actions/install-postgres/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
       env:
         pg_build_args: --enable-debug --enable-cassert
-        llvm_config: llvm-config-14
+        llvm_config: llvm-config-18
         CC: gcc
         CXX: g++
       run: |


### PR DESCRIPTION
I couldn't built packages anymore because LLVM 14 was trying to do something with the output of LLVM 18, which it was incompatible with. This fixes that by using the latest LLVM to build Debian packages.