### PR TITLE
Update page slot size computation to take alignment into account

### DIFF
--- a/pgvectorscale/src/util/chain.rs
+++ b/pgvectorscale/src/util/chain.rs
@@ -31,10 +31,6 @@ struct ChainItemHeader {
 
 const CHAIN_ITEM_HEADER_SIZE: usize = std::mem::size_of::<ArchivedChainItemHeader>();
 
-// Empirically-measured slop factor for how much `pg_sys::PageGetFreeSpace` can
-// overestimate the free space in a page in our usage patterns.
-const PG_SLOP_SIZE: usize = 4;
-
 pub struct ChainTapeWriter<'a, S: StatsNodeWrite> {
     page_type: PageType,
     index: &'a PgRelation,
@@ -81,7 +77,7 @@ impl<'a, S: StatsNodeWrite> ChainTapeWriter<'a, S> {
         let mut current_page = WritablePage::modify(self.index, self.current);
 
         // If there isn't enough space for the header plus some data, start a new page.
-        if current_page.get_free_space() < CHAIN_ITEM_HEADER_SIZE + PG_SLOP_SIZE + 1 {
+        if current_page.get_aligned_free_space() < CHAIN_ITEM_HEADER_SIZE + 1 {
             current_page = WritablePage::new(self.index, self.page_type);
             self.current = current_page.get_block_number();
         }
@@ -90,13 +86,13 @@ impl<'a, S: StatsNodeWrite> ChainTapeWriter<'a, S> {
         let mut result: Option<super::ItemPointer> = None;
 
         // Write the data in chunks, creating new pages as needed.
-        while CHAIN_ITEM_HEADER_SIZE + data.len() + PG_SLOP_SIZE > current_page.get_free_space() {
+        while CHAIN_ITEM_HEADER_SIZE + data.len() > current_page.get_aligned_free_space() {
             let next_page = WritablePage::new(self.index, self.page_type);
             let header = ChainItemHeader {
                 next: ItemPointer::new(next_page.get_block_number(), 1),
             };
             let header_bytes = rkyv::to_bytes::<_, 256>(&header).unwrap();
-            let data_size = current_page.get_free_space() - PG_SLOP_SIZE - CHAIN_ITEM_HEADER_SIZE;
+            let data_size = current_page.get_aligned_free_space() - CHAIN_ITEM_HEADER_SIZE;
             let chunk = &data[..data_size];
             let combined = [header_bytes.as_slice(), chunk].concat();
             let offset_number = current_page.add_item(combined.as_ref());

--- a/pgvectorscale/src/util/page.rs
+++ b/pgvectorscale/src/util/page.rs
@@ -192,8 +192,15 @@ impl<'a> WritablePage<'a> {
         self.buffer.get_block_number()
     }
 
-    pub fn get_free_space(&self) -> usize {
+    fn get_free_space(&self) -> usize {
         unsafe { pg_sys::PageGetFreeSpace(self.page) }
+    }
+
+    /// The actual free space that can be used to store data.
+    /// See https://github.com/postgres/postgres/blob/0164a0f9ee12e0eff9e4c661358a272ecd65c2d4/src/backend/storage/page/bufpage.c#L304
+    pub fn get_aligned_free_space(&self) -> usize {
+        let free_space = self.get_free_space();
+        free_space - (free_space % 8)
     }
 
     pub fn get_type(&self) -> PageType {

--- a/pgvectorscale/src/util/tape.rs
+++ b/pgvectorscale/src/util/tape.rs
@@ -47,23 +47,18 @@ impl<'a> Tape<'a> {
         }
     }
 
-    /// Align the size to the nearest multiple of 8.
-    fn aligned_size(size: usize) -> usize {
-        (size + 7) & !7
-    }
-
     pub unsafe fn write(&mut self, data: &[u8]) -> super::ItemPointer {
-        let size = Self::aligned_size(data.len());
+        let size = data.len();
         assert!(size < BLCKSZ as usize);
         assert!(!self.page_type.is_chained());
 
         let mut current_page = WritablePage::modify(self.index, self.current);
 
         // Don't split data over pages.  (See chain.rs for that.)
-        if current_page.get_free_space() < size {
+        if current_page.get_aligned_free_space() < size {
             current_page = WritablePage::new(self.index, self.page_type);
             self.current = current_page.get_block_number();
-            if current_page.get_free_space() < size {
+            if current_page.get_aligned_free_space() < size {
                 panic!("Not enough free space on new page");
             }
         }
@@ -99,34 +94,6 @@ mod tests {
             .unwrap()
             .expect("oid was null");
         unsafe { PgRelation::from_pg(pg_sys::RelationIdGetRelation(index_oid)) }
-    }
-
-    #[pg_test]
-    fn test_aligned_size() {
-        // Test various sizes to verify alignment behavior
-        let test_cases = vec![
-            (0, 0),   // 0 should align to 0
-            (1, 8),   // 1 should align to 8
-            (7, 8),   // 7 should align to 8
-            (8, 8),   // 8 should stay at 8
-            (9, 16),  // 9 should align to 16
-            (15, 16), // 15 should align to 16
-            (16, 16), // 16 should stay at 16
-            (17, 24), // 17 should align to 24
-            (23, 24), // 23 should align to 24
-            (24, 24), // 24 should stay at 24
-        ];
-
-        for (input, expected) in test_cases {
-            assert_eq!(
-                Tape::aligned_size(input),
-                expected,
-                "Size {} should align to {}, but got {}",
-                input,
-                expected,
-                Tape::aligned_size(input)
-            );
-        }
     }
 
     #[pg_test]
@@ -186,7 +153,7 @@ mod tests {
                 );
 
                 let page = WritablePage::modify(tape.index, tape.current);
-                assert_eq!(page.get_free_space(), 8108);
+                assert_eq!(page.get_aligned_free_space(), 8104);
             }
 
             {


### PR DESCRIPTION
Fix failed assertion in `WritablePage::add_item_unchecked` when testing with labeled yfcc dataset.  Postgres adds alignment padding if needed when inserting items to page:

https://github.com/postgres/postgres/blob/0164a0f9ee12e0eff9e4c661358a272ecd65c2d4/src/backend/storage/page/bufpage.c#L304

We need to take this alignment into account when calculating whether an item will fit.  This PR also replaces existing logic in ChainTape with the new tighter calculation.