### PR TITLE
Added an option "bq_distance_fn" which can switch distance metric of binary quantized data

### DIFF
--- a/pgvectorscale/src/access_method/build.rs
+++ b/pgvectorscale/src/access_method/build.rs
@@ -75,11 +75,12 @@ pub extern "C" fn ambuild(
     let opt = TSVIndexOptions::from_relation(&index_relation);
 
     notice!(
-        "Starting index build with num_neighbors={}, search_list_size={}, max_alpha={}, storage_layout={:?}.",
+        "Starting index build with num_neighbors={}, search_list_size={}, max_alpha={}, storage_layout={:?}, bq_distance_fn={:?}.",
         opt.get_num_neighbors(),
         opt.search_list_size,
         opt.max_alpha,
         opt.get_storage_type(),
+        opt.get_bq_distance_fn(),
     );
 
     let dimensions = index_relation.tuple_desc().get(0).unwrap().atttypmod;

--- a/pgvectorscale/src/access_method/distance.rs
+++ b/pgvectorscale/src/access_method/distance.rs
@@ -257,6 +257,16 @@ macro_rules! xor_arm {
     };
 }
 
+macro_rules! and_arm {
+    ($a: expr, $b: expr, $sz: expr) => {
+        $a[..$sz]
+            .iter()
+            .zip($b[..$sz].iter())
+            .map(|(&l, &r)| (l & r).count_ones() as isize)
+            .sum::<isize>()
+    };
+}
+
 #[inline(always)]
 pub fn distance_xor_optimized(a: &[u64], b: &[u64]) -> usize {
     match a.len() {
@@ -314,6 +324,66 @@ pub fn distance_xor_optimized(a: &[u64], b: &[u64]) -> usize {
             .zip(b.iter())
             .map(|(&l, &r)| (l ^ r).count_ones() as usize)
             .sum(),
+    }
+}
+
+#[inline(always)]
+pub fn distance_and_optimized(a: &[u64], b: &[u64]) -> isize {
+    match a.len() {
+        1 => -and_arm!(a, b, 1),
+        2 => -and_arm!(a, b, 2),
+        3 => -and_arm!(a, b, 3),
+        4 => -and_arm!(a, b, 4),
+        5 => -and_arm!(a, b, 5),
+        6 => -and_arm!(a, b, 6),
+        7 => -and_arm!(a, b, 7),
+        8 => -and_arm!(a, b, 8),
+        9 => -and_arm!(a, b, 9),
+        10 => -and_arm!(a, b, 10),
+        11 => -and_arm!(a, b, 11),
+        12 => -and_arm!(a, b, 12),
+        13 => -and_arm!(a, b, 13),
+        14 => -and_arm!(a, b, 14),
+        15 => -and_arm!(a, b, 15),
+        16 => -and_arm!(a, b, 16),
+        17 => -and_arm!(a, b, 17),
+        18 => -and_arm!(a, b, 18),
+        19 => -and_arm!(a, b, 19),
+        20 => -and_arm!(a, b, 20),
+        21 => -and_arm!(a, b, 21),
+        22 => -and_arm!(a, b, 22),
+        23 => -and_arm!(a, b, 23),
+        24 => -and_arm!(a, b, 24),
+        25 => -and_arm!(a, b, 25),
+        26 => -and_arm!(a, b, 26),
+        27 => -and_arm!(a, b, 27),
+        28 => -and_arm!(a, b, 28),
+        29 => -and_arm!(a, b, 29),
+        30 => -and_arm!(a, b, 30),
+        31 => -and_arm!(a, b, 31),
+        32 => -and_arm!(a, b, 32),
+        33 => -and_arm!(a, b, 33),
+        34 => -and_arm!(a, b, 34),
+        35 => -and_arm!(a, b, 35),
+        36 => -and_arm!(a, b, 36),
+        37 => -and_arm!(a, b, 37),
+        38 => -and_arm!(a, b, 38),
+        39 => -and_arm!(a, b, 39),
+        40 => -and_arm!(a, b, 40),
+        41 => -and_arm!(a, b, 41),
+        42 => -and_arm!(a, b, 42),
+        43 => -and_arm!(a, b, 43),
+        44 => -and_arm!(a, b, 44),
+        45 => -and_arm!(a, b, 45),
+        46 => -and_arm!(a, b, 46),
+        47 => -and_arm!(a, b, 47),
+        48 => -and_arm!(a, b, 48),
+        49 => -and_arm!(a, b, 49),
+        _ => -a
+            .iter()
+            .zip(b.iter())
+            .map(|(&l, &r)| (l & r).count_ones() as isize)
+            .sum::<isize>(),
     }
 }
 

--- a/pgvectorscale/src/access_method/meta_page.rs
+++ b/pgvectorscale/src/access_method/meta_page.rs
@@ -224,6 +224,10 @@ impl MetaPage {
         self.bq_num_bits_per_dimension
     }
 
+    pub fn get_bq_distance_fn(&self) -> &str {
+        "distance_xor_optimized"
+    }
+
     /// Maximum number of neigbors per node. Given that we pre-allocate
     /// these many slots for each node, this cannot change after the graph is built.
     pub fn get_num_neighbors(&self) -> u32 {


### PR DESCRIPTION
In the current pgvectorscale, regardless of whether the original vector distance is based on cosine, inner product, or L2, a Binary Quantized vector uses Hamming distance.
Although Hamming distance can be quickly computed via bitwise XOR, it may not always be the most suitable measure depending on the combination of database and query.

By specifying `"distance_and_optimized"` for the added bq_distance_fn option, the distance of a Binary Quantized vectors is calculated as the negative of the number of common elements, which is found using bitwise AND.
The number of common elements is the numerator of the Jaccard index and is equivalent to the inner product of the Binary Quantized vectors.
Depending on the combination of database and query, this approach might yield better results than Hamming distance.