### PR TITLE
Automatically add Debian packages to GitHub release

### DIFF
--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -104,3 +104,7 @@ jobs:
       run: |
         source /etc/os-release
         package_cloud push timescale/timescaledb/$ID/$VERSION_CODENAME pkgdump/pgvectorscale-*${{ env.TAG }}*.deb
+
+    - name: Upload artifacts to GitHub release
+      run: |
+        gh release upload ${{ TAG }} pkgdump/pgvectorscale-*${{ env.TAG }}*.deb

--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -44,6 +44,9 @@ jobs:
       TAG_DIR: pgvectorscale
       TAG_GIT_REF: ${{ github.event.inputs.TAG_GIT_REF == '' && github.event.inputs.tag || github.event.inputs.TAG_GIT_REF}}
 
+    permissions:
+      contents: write
+
     steps:
     - name: Install package_cloud
       run: |

--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -106,5 +106,7 @@ jobs:
         package_cloud push timescale/timescaledb/$ID/$VERSION_CODENAME pkgdump/pgvectorscale-*${{ env.TAG }}*.deb
 
     - name: Upload artifacts to GitHub release
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh release upload ${{ env.TAG }} pkgdump/pgvectorscale-*${{ env.TAG }}*.deb

--- a/.github/workflows/deb-packager.yaml
+++ b/.github/workflows/deb-packager.yaml
@@ -107,4 +107,4 @@ jobs:
 
     - name: Upload artifacts to GitHub release
       run: |
-        gh release upload ${{ TAG }} pkgdump/pgvectorscale-*${{ env.TAG }}*.deb
+        gh release upload ${{ env.TAG }} pkgdump/pgvectorscale-*${{ env.TAG }}*.deb


### PR DESCRIPTION
This automatically uploads the release artifacts to the release on GitHub, to avoid needing to manually download/upload 12 different files every release.