### PR TITLE
Use base actions image for rustfmt check

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -7,9 +7,6 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
 
-    container:
-      image: timescaledev/rust-builder:ubuntu-1.65
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The `timescaledev/rust-builder` is outdated, and we don't need it anyways because everything in it we need is in the base GH Actions image. This fixes the CI failure in #240 stemming from this action's Docker image using an outdated Rust compiler.

It also speeds up the check significantly, because we don't need to wait for the Docker image to be setup anymore.