### PR TITLE
fix: hold meta-page lock across reinit and writes in MetaPage::store

### DIFF
--- a/pgvectorscale/src/access_method/meta_page.rs
+++ b/pgvectorscale/src/access_method/meta_page.rs
@@ -15,8 +15,8 @@ use crate::access_method::graph::start_nodes::StartNodes;
 use crate::access_method::node::{ReadableNode, WriteableNode};
 use crate::access_method::options::TSVIndexOptions;
 use crate::access_method::stats::WriteStats;
-use crate::util::chain::{ChainItemReader, ChainTapeWriter};
-use crate::util::page::{self, PageType};
+use crate::util::chain::{write_chain_item_to_page, ChainItemReader};
+use crate::util::page::{self, PageType, WritablePage};
 use crate::util::*;
 
 const TSV_MAGIC_NUMBER: u32 = 768756476; //Magic number, random
@@ -365,22 +365,28 @@ impl MetaPage {
         assert!(header.magic_number == TSV_MAGIC_NUMBER);
         assert!(header.version == TSV_VERSION);
 
-        let mut stats = WriteStats::default();
-        let mut tape = if first_time {
-            ChainTapeWriter::new(index, PageType::Meta, &mut stats)
+        let header_bytes = header.serialize_to_vec();
+        let meta_bytes = self.serialize_to_vec();
+
+        // Hold the exclusive page lock across reinit, header, and meta
+        // writes so concurrent callers (e.g. parallel index-build workers
+        // all finalizing at once) can't interleave reinit and write and
+        // race on block 0. See issue #264.
+        let mut page = if first_time {
+            WritablePage::new(index, PageType::Meta)
         } else {
-            ChainTapeWriter::reinit(index, PageType::Meta, &mut stats, META_BLOCK_NUMBER)
+            let mut p = WritablePage::modify(index, META_BLOCK_NUMBER);
+            p.reinit(PageType::Meta);
+            p
         };
 
-        // Serialize the header
-        let bytes = header.serialize_to_vec();
-        let off = tape.write(&bytes);
-        assert_eq!(off, ItemPointer::new(META_BLOCK_NUMBER, META_HEADER_OFFSET));
+        let header_off = write_chain_item_to_page(&mut page, &header_bytes);
+        assert_eq!(header_off, META_HEADER_OFFSET);
 
-        // Serialize the meta
-        let bytes = self.serialize_to_vec();
-        let off = tape.write(&bytes);
-        assert_eq!(off, ItemPointer::new(META_BLOCK_NUMBER, META_OFFSET));
+        let meta_off = write_chain_item_to_page(&mut page, &meta_bytes);
+        assert_eq!(meta_off, META_OFFSET);
+
+        page.commit();
     }
 
     unsafe fn load(index: &PgRelation) -> MetaPage {

--- a/pgvectorscale/src/util/chain.rs
+++ b/pgvectorscale/src/util/chain.rs
@@ -11,7 +11,7 @@
 //! of the data.
 
 use pgrx::{
-    pg_sys::{BlockNumber, InvalidBlockNumber},
+    pg_sys::{BlockNumber, InvalidBlockNumber, OffsetNumber},
     PgRelation,
 };
 use rkyv::{Archive, Deserialize, Serialize};
@@ -31,6 +31,18 @@ struct ChainItemHeader {
 
 const CHAIN_ITEM_HEADER_SIZE: usize = std::mem::size_of::<ArchivedChainItemHeader>();
 
+/// Append a single chain-item to `page`. Caller retains the exclusive
+/// lock; the item must fit on this page (no chaining). Returns the
+/// offset number of the new item.
+pub fn write_chain_item_to_page(page: &mut WritablePage, data: &[u8]) -> OffsetNumber {
+    let header = ChainItemHeader {
+        next: ItemPointer::new_invalid(),
+    };
+    let header_bytes = rkyv::to_bytes::<_, 256>(&header).unwrap();
+    let combined = [header_bytes.as_slice(), data].concat();
+    page.add_item(&combined)
+}
+
 pub struct ChainTapeWriter<'a, S: StatsNodeWrite> {
     page_type: PageType,
     index: &'a PgRelation,
@@ -45,25 +57,6 @@ impl<'a, S: StatsNodeWrite> ChainTapeWriter<'a, S> {
         let page = WritablePage::new(index, page_type);
         let block_number = page.get_block_number();
         page.commit();
-        Self {
-            page_type,
-            index,
-            current: block_number,
-            stats,
-        }
-    }
-
-    pub fn reinit(
-        index: &'a PgRelation,
-        page_type: PageType,
-        stats: &'a mut S,
-        block_number: BlockNumber,
-    ) -> Self {
-        assert!(page_type.is_chained());
-        let mut page = WritablePage::modify(index, block_number);
-        page.reinit(page_type);
-        page.commit();
-
         Self {
             page_type,
             index,


### PR DESCRIPTION
## Summary

Parallel DiskANN index builds can fail with `assertion 'left == right' failed` (see #264). Every parallel worker calls `MetaPage::store(false)` from `finalize_index_build` (`build.rs:940`), and `store()` released the exclusive buffer lock between `reinit` and each subsequent `write`. Concurrent workers could interleave the operations and produce the observed offset mismatch.

This PR restructures `MetaPage::store` to hold one `WritablePage` across reinit and both writes, committing once at the end. Concurrent callers now serialize on the Postgres buffer lock.

Note for reviewers: the root cause is slightly different from what's described in #264 — the `MetaV1` branch of `fetch()` is not the trigger. Freshly built indexes use `PageType::Meta`, and `fetch()` on that branch is read-only (`Self::load`). The race I'm seeing is in `MetaPage::store` itself, exercised from `finalize_index_build` in each parallel worker.

## Changes

- `pgvectorscale/src/access_method/meta_page.rs` — `store()` now acquires a single `WritablePage` (via `new` for `first_time=true`, or `modify` + in-place `reinit` for `first_time=false`), writes header + meta, and commits once.
- `pgvectorscale/src/util/chain.rs` — new `write_chain_item_to_page(page, data)` helper for the single-item, caller-holds-lock case (keeps the `ChainItemHeader` serialization format in one module). Removed the now-unused `ChainTapeWriter::reinit`.

Net diff: +33 / −34 lines across 2 files.

## Test plan

- [x] `cargo pgrx install --release --features pg18` builds cleanly; no new clippy warnings on the changed files.
- [x] **Reproduced the race** on `main` with a 50 ms `sleep` inserted between `reinit` and the first `write` in `store()`: 4 of 5 iterations fail with the exact assertion from #264.
- [x] **Verified the fix** — with the patch applied *and* a 50 ms `sleep` inserted inside the single lock window to stress serialization: 5 of 5 iterations pass.
- [ ] `cargo pgrx test pg{17,18}` — to be confirmed by CI (local run blocked by a pgrx `--sudo` install quirk on macOS, unrelated to this change).

Repro script preserved for convenience:

```sql
DROP TABLE IF EXISTS v;
CREATE TABLE v (id SERIAL PRIMARY KEY, embedding vector(64));
INSERT INTO v (embedding)
SELECT (SELECT array_agg(random()::real) FROM generate_series(1, 64))::vector
FROM generate_series(1, 50000);

SET diskann.min_vectors_for_parallel_build = 100;
SET max_parallel_maintenance_workers = 16;
SET diskann.force_parallel_workers = 16;

DO $$ BEGIN FOR i IN 1..5 LOOP
    BEGIN
        EXECUTE 'DROP INDEX IF EXISTS v_diskann_idx';
        EXECUTE 'CREATE INDEX v_diskann_idx ON v USING diskann (embedding vector_l2_ops)
                 WITH (storage_layout = ''memory_optimized'')';
        RAISE NOTICE 'Iteration % succeeded', i;
    EXCEPTION WHEN others THEN
        RAISE NOTICE 'Iteration % FAILED: %', i, SQLERRM;
    END;
END LOOP; END $$;
```

## Notes

I intentionally did not add an in-tree regression test because reproducing the bug deterministically requires injecting a sleep inside `store()`. Happy to add a `#[cfg(test)]`-gated race-widener test on request.

Fixes #264