### PR TITLE
style: qualify pg_catalog schema references in extension SQL

### DIFF
--- a/pgvectorscale/sql/vectorscale--0.4.0--0.5.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.4.0--0.5.0.sql
@@ -89,9 +89,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade to add L2 distance support and update cosine opclass to
         -- include the distance_type_cosine function
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
 
         CREATE OPERATOR CLASS vector_l2_ops

--- a/pgvectorscale/sql/vectorscale--0.5.0--0.5.1.sql
+++ b/pgvectorscale/sql/vectorscale--0.5.0--0.5.1.sql
@@ -89,9 +89,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade to add L2 distance support and update cosine opclass to
         -- include the distance_type_cosine function
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
 
         CREATE OPERATOR CLASS vector_l2_ops

--- a/pgvectorscale/sql/vectorscale--0.5.1--0.6.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.5.1--0.6.0.sql
@@ -102,9 +102,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 

--- a/pgvectorscale/sql/vectorscale--0.6.0--0.7.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.6.0--0.7.0.sql
@@ -124,9 +124,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 

--- a/pgvectorscale/sql/vectorscale--0.6.0--0.7.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.6.0--0.7.0.sql
@@ -146,7 +146,7 @@ BEGIN
     
     -- First, check if the && operator exists for smallint[]
     IF NOT EXISTS (
-        SELECT 1 FROM pg_operator 
+        SELECT 1 FROM pg_catalog.pg_operator 
         WHERE oprname = '&&' 
         AND oprleft = 'smallint[]'::regtype 
         AND oprright = 'smallint[]'::regtype

--- a/pgvectorscale/sql/vectorscale--0.7.0--0.7.1.sql
+++ b/pgvectorscale/sql/vectorscale--0.7.0--0.7.1.sql
@@ -124,9 +124,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 

--- a/pgvectorscale/sql/vectorscale--0.7.0--0.7.1.sql
+++ b/pgvectorscale/sql/vectorscale--0.7.0--0.7.1.sql
@@ -146,7 +146,7 @@ BEGIN
     
     -- First, check if the && operator exists for smallint[]
     IF NOT EXISTS (
-        SELECT 1 FROM pg_operator 
+        SELECT 1 FROM pg_catalog.pg_operator 
         WHERE oprname = '&&' 
         AND oprleft = 'smallint[]'::regtype 
         AND oprright = 'smallint[]'::regtype

--- a/pgvectorscale/sql/vectorscale--0.7.1--0.8.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.7.1--0.8.0.sql
@@ -124,9 +124,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 

--- a/pgvectorscale/sql/vectorscale--0.7.1--0.8.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.7.1--0.8.0.sql
@@ -146,7 +146,7 @@ BEGIN
 
     -- First, check if the && operator exists for smallint[]
     IF NOT EXISTS (
-        SELECT 1 FROM pg_operator
+        SELECT 1 FROM pg_catalog.pg_operator
         WHERE oprname = '&&'
         AND oprleft = 'smallint[]'::regtype
         AND oprright = 'smallint[]'::regtype

--- a/pgvectorscale/sql/vectorscale--0.8.0--0.9.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.8.0--0.9.0.sql
@@ -124,9 +124,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 

--- a/pgvectorscale/sql/vectorscale--0.8.0--0.9.0.sql
+++ b/pgvectorscale/sql/vectorscale--0.8.0--0.9.0.sql
@@ -146,7 +146,7 @@ BEGIN
     
     -- First, check if the && operator exists for smallint[]
     IF NOT EXISTS (
-        SELECT 1 FROM pg_operator 
+        SELECT 1 FROM pg_catalog.pg_operator 
         WHERE oprname = '&&' 
         AND oprleft = 'smallint[]'::regtype 
         AND oprright = 'smallint[]'::regtype

--- a/pgvectorscale/src/access_method/mod.rs
+++ b/pgvectorscale/src/access_method/mod.rs
@@ -212,9 +212,9 @@ BEGIN
     ELSIF have_l2_ops = 0 THEN
         -- Upgrade from 0.4.0 to 0.5.0.  Update cosine opclass to include
         -- the distance_type_cosine function.
-        INSERT INTO pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
-        SELECT  (select (max(oid)::int + 1)::oid from pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
-        FROM pg_opclass c, pg_am a
+        INSERT INTO pg_catalog.pg_amproc (oid, amprocfamily, amproclefttype, amprocrighttype, amprocnum, amproc)
+        SELECT  (select (max(oid)::int + 1)::oid from pg_catalog.pg_amproc), c.opcfamily, c.opcintype, c.opcintype, 1, '@extschema@.distance_type_l2'::regproc
+        FROM pg_catalog.pg_opclass c, pg_catalog.pg_am a
         WHERE a.oid = c.opcmethod AND c.opcname = 'vector_cosine_ops' AND a.amname = 'diskann';
     END IF;
 
@@ -234,7 +234,7 @@ BEGIN
     
     -- First, check if the && operator exists for smallint[]
     IF NOT EXISTS (
-        SELECT 1 FROM pg_operator 
+        SELECT 1 FROM pg_catalog.pg_operator 
         WHERE oprname = '&&' 
         AND oprleft = 'smallint[]'::regtype 
         AND oprright = 'smallint[]'::regtype


### PR DESCRIPTION
Add explicit `pg_catalog.` prefix to all unqualified system catalog
references in extension scripts and update paths (`pg_amproc`,
`pg_opclass`, `pg_am`, `pg_operator`).