### PR TITLE
BUGFIX: per-scan TupleDesc/slot leak and per-rescan state leak

### DIFF
--- a/pgvectorscale/src/access_method/scan.rs
+++ b/pgvectorscale/src/access_method/scan.rs
@@ -54,6 +54,24 @@ impl TSVScanState {
         }
     }
 
+    /// Release the current iteration's [`StorageState`], if any.
+    ///
+    /// The state is owned by this struct: `initialize` publishes it with
+    /// [`Box::into_raw`] and this reclaims it with [`Box::from_raw`]. Keeping it a
+    /// raw pointer (rather than an `Option<Box<_>>`) preserves the existing call
+    /// sites, which need `&mut TSVScanState` at the same time as the state itself.
+    ///
+    /// The pointer is nulled out immediately, so calling this repeatedly -- as
+    /// `amendscan` and then `Drop` do -- can never double free.
+    fn release_storage(&mut self) {
+        if !self.storage.is_null() {
+            // SAFETY: `storage` is null or a pointer from `Box::into_raw` in
+            // `initialize`; it is nulled below before any other code can observe it.
+            drop(unsafe { Box::from_raw(self.storage) });
+            self.storage = std::ptr::null_mut();
+        }
+    }
+
     fn initialize(
         &mut self,
         index: &PgRelation,
@@ -83,8 +101,24 @@ impl TSVScanState {
             }
         };
 
-        self.storage = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(store_type);
+        // Release the previous iteration before publishing the new one. `amrescan`
+        // re-enters `initialize` for every rescan (nested-loop / lateral joins);
+        // previously each call leaked a fresh `StorageState` -- a response iterator
+        // plus a cloned quantizer -- into the executor's per-query memory context
+        // without dropping the one it replaced, so those piled up for the lifetime
+        // of the whole query instead of the scan.
+        self.release_storage();
+        self.storage = Box::into_raw(Box::new(store_type));
         self.distance_fn = Some(distance);
+    }
+}
+
+impl Drop for TSVScanState {
+    fn drop(&mut self) {
+        // Backstop for scans torn down without `amendscan` (e.g. an aborted query):
+        // the state object itself is released when the per-query memory context is
+        // reset, and this releases the storage it owns.
+        self.release_storage();
     }
 }
 
@@ -437,22 +471,29 @@ fn get_tuple(
 
 #[pg_guard]
 pub extern "C-unwind" fn amendscan(scan: pg_sys::IndexScanDesc) {
+    let scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
+    let state = unsafe { (scan.opaque as *mut TSVScanState).as_mut() }.expect("no scandesc state");
+
     let min_level = unsafe {
         let l = pg_sys::log_min_messages;
         let c = pg_sys::client_min_messages;
         std::cmp::min(l, c)
     };
     if min_level <= pg_sys::DEBUG1 as _ {
-        let scan: PgBox<pg_sys::IndexScanDescData> = unsafe { PgBox::from_pg(scan) };
-        let state =
-            unsafe { (scan.opaque as *mut TSVScanState).as_mut() }.expect("no scandesc state");
-
-        let mut storage = unsafe { state.storage.as_mut() }.expect("no storage in state");
-        match &mut storage {
-            StorageState::SbqSpeedup(_bq, iter) => end_scan::<SbqSpeedupStorage>(iter),
-            StorageState::Plain(iter) => end_scan::<PlainStorage>(iter),
+        // A scan that is ended without ever having been rescanned has no storage,
+        // which is not an error -- only report stats when there are some.
+        if let Some(storage) = unsafe { state.storage.as_mut() } {
+            match storage {
+                StorageState::SbqSpeedup(_bq, iter) => end_scan::<SbqSpeedupStorage>(iter),
+                StorageState::Plain(iter) => end_scan::<PlainStorage>(iter),
+            }
         }
     }
+
+    // Release the scan's state at end of scan instead of deferring to the
+    // executor's per-query context teardown, so a query that opens many scans does
+    // not hold every iterator (and cloned quantizer) alive until it completes.
+    state.release_storage();
 }
 
 fn end_scan<S: Storage>(
@@ -473,4 +514,62 @@ fn end_scan<S: Storage>(
 
     debug_assert_eq!(iter.quantizer_stats.node_reads, 1);
     debug_assert_eq!(iter.quantizer_stats.node_writes, 0);
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::{pg_test, spi, Spi};
+
+    /// Exercises repeated rescans of a diskann index inside a single statement.
+    ///
+    /// `amrescan` re-enters [`TSVScanState::initialize`] once per outer row of a
+    /// nested-loop / lateral join, and `amendscan` ends the scan. Each of those
+    /// must release the previous iteration's `StorageState` -- the response
+    /// iterator plus a cloned quantizer -- rather than letting one accumulate per
+    /// rescan until the whole query finishes.
+    ///
+    /// Beyond covering that path, this guards the release itself: an incorrect
+    /// ownership transfer would double free or use freed memory here and crash the
+    /// backend, not merely leak. The heap is deliberately churned first so the
+    /// rescore path also encounters dead / invisible tuples.
+    #[pg_test]
+    fn diskann_rescan_releases_state_each_iteration() -> spi::Result<()> {
+        Spi::run(
+            "CREATE TABLE rescan_test(id int, embedding vector(3));
+             INSERT INTO rescan_test(id, embedding)
+             SELECT g, ('[' || g || ',' || (g % 7) || ',' || (g % 5) || ']')::vector
+               FROM generate_series(1, 200) g;
+             CREATE INDEX ON rescan_test USING diskann (embedding);",
+        )?;
+
+        // Churn the heap so some index entries point at dead / superseded tuples.
+        Spi::run("UPDATE rescan_test SET embedding = embedding WHERE id % 3 = 0;")?;
+        Spi::run("DELETE FROM rescan_test WHERE id % 11 = 0;")?;
+
+        // Make the planner prefer the index so the lateral really does rescan it.
+        Spi::run("SET enable_seqscan = off;")?;
+
+        // One diskann rescan per outer row: 25 rescans in a single statement.
+        let neighbors = Spi::get_one::<i64>(
+            "SELECT count(*) FROM (
+                 SELECT o.id AS oid, n.id AS nid
+                   FROM (SELECT id, embedding FROM rescan_test ORDER BY id LIMIT 25) o
+                   CROSS JOIN LATERAL (
+                       SELECT i.id
+                         FROM rescan_test i
+                        ORDER BY i.embedding <=> o.embedding
+                        LIMIT 3
+                   ) n
+             ) s",
+        )?
+        .expect("count should not be null");
+
+        assert_eq!(
+            neighbors, 75,
+            "each of the 25 outer rows should contribute 3 neighbours across rescans"
+        );
+
+        Ok(())
+    }
 }

--- a/pgvectorscale/src/util/table_slot.rs
+++ b/pgvectorscale/src/util/table_slot.rs
@@ -21,6 +21,18 @@ impl TableSlot {
             std::ptr::null_mut(),
         ));
 
+        // Arm the RAII wrapper IMMEDIATELY, before any fallible work.
+        //
+        // `table_slot_create` -> `MakeTupleTableSlot` calls `PinTupleDesc` on the
+        // heap relation's rowtype descriptor, and that pin is released only by
+        // `TableSlot::drop` -> `ExecDropSingleTupleTableSlot`. Constructing `Self`
+        // here means every exit path below — the `!valid` early return, and any
+        // unwind out of the fetch or the assert — drops the slot and releases the
+        // descriptor pin. Previously the wrapper was built only on the success
+        // path, so a heap pointer with no snapshot-visible tuple leaked both the
+        // slot and its TupleDesc reference on every rescored candidate.
+        let table_slot = Self { slot };
+
         let table_am = heap_rel.rd_tableam;
         let mut ctid: pg_sys::ItemPointerData = pg_sys::ItemPointerData {
             ..Default::default()
@@ -35,7 +47,7 @@ impl TableSlot {
             scan,
             &mut ctid,
             snapshot,
-            slot.as_ptr(),
+            table_slot.slot.as_ptr(),
             &mut call_again,
             &mut all_dead,
         );
@@ -45,11 +57,13 @@ impl TableSlot {
         stats.record_heap_read();
 
         if !valid {
-            /* no valid tuples found in HOT-chain */
+            /* No visible tuple in the HOT chain (deleted / updated-away / not yet
+             * vacuumed). Dropping `table_slot` here frees the slot and releases its
+             * rowtype TupleDesc pin. */
             return None;
         }
 
-        Some(Self { slot })
+        Some(table_slot)
     }
 
     pub unsafe fn get_attribute(&self, attribute_number: pg_sys::AttrNumber) -> Option<Datum> {
@@ -60,5 +74,99 @@ impl TableSlot {
 impl Drop for TableSlot {
     fn drop(&mut self) {
         unsafe { pg_sys::ExecDropSingleTupleTableSlot(self.slot.as_ptr()) };
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use pgrx::{pg_sys, pg_test, Spi};
+
+    use super::*;
+    use crate::access_method::stats::GreedySearchStats;
+
+    /// Parse a `ctid` in its text form, e.g. `"(0,1)"`.
+    fn parse_ctid(ctid: &str) -> (pg_sys::BlockNumber, pg_sys::OffsetNumber) {
+        let inner = ctid.trim_matches(|c| c == '(' || c == ')');
+        let mut parts = inner.split(',');
+        let block = parts
+            .next()
+            .expect("ctid should have a block number")
+            .trim()
+            .parse()
+            .expect("block number should parse");
+        let offset = parts
+            .next()
+            .expect("ctid should have an offset")
+            .trim()
+            .parse()
+            .expect("offset number should parse");
+        (block, offset)
+    }
+
+    /// Regression test for the per-scan `TupleDesc` + slot leak (issue #211).
+    ///
+    /// [`TableSlot::from_index_heap_pointer`] builds a `TupleTableSlot` with
+    /// `table_slot_create`, which pins the heap relation's rowtype `TupleDesc`;
+    /// that pin is released only by [`TableSlot`]'s `Drop`. When the heap pointer
+    /// has no snapshot-visible tuple the function returns `None`. If the RAII
+    /// wrapper is armed only on the success path, that early return leaks both the
+    /// slot and the descriptor pin -- once per dead/invisible rescored candidate --
+    /// which surfaces as `resource was not closed: TupleDesc ... (<oid>,-1)` at
+    /// ResourceOwner release and as unbounded backend memory growth on tables with
+    /// ongoing updates/deletes.
+    ///
+    /// The descriptor's reference count must therefore be conserved across a call
+    /// that takes the no-visible-tuple path.
+    #[pg_test]
+    unsafe fn table_slot_releases_tupledesc_on_dead_tuple() {
+        Spi::run(
+            "CREATE TABLE slot_leak_test(encoding vector(3));
+             INSERT INTO slot_leak_test(encoding) VALUES ('[1,2,3]');",
+        )
+        .unwrap();
+
+        // Note where the row lives, then delete it, so that a snapshot taken
+        // afterwards finds no visible version at that TID -- the path under test.
+        let ctid = Spi::get_one::<String>("SELECT ctid::text FROM slot_leak_test LIMIT 1")
+            .unwrap()
+            .expect("the inserted row should exist");
+        let (block, offset) = parse_ctid(&ctid);
+        Spi::run("DELETE FROM slot_leak_test;").unwrap();
+
+        let heap_oid = Spi::get_one::<pg_sys::Oid>("SELECT 'slot_leak_test'::regclass::oid")
+            .unwrap()
+            .expect("the relation should exist");
+        // Open with a lock, exactly as the executor does before any table-AM
+        // fetch. `PgRelation::with_lock` also closes and unlocks on drop.
+        let heap_rel = PgRelation::with_lock(heap_oid, pg_sys::AccessShareLock as pg_sys::LOCKMODE);
+
+        let tupdesc = heap_rel.rd_att;
+        assert!(
+            (*tupdesc).tdrefcount >= 0,
+            "the relcache descriptor must be reference-counted for this test to be meaningful"
+        );
+        let refcount_before = (*tupdesc).tdrefcount;
+
+        let mut stats = GreedySearchStats::default();
+        let slot = TableSlot::from_index_heap_pointer(
+            &heap_rel,
+            HeapPointer::new(block, offset),
+            // The statement's own registered snapshot. It was taken after the
+            // DELETE above, so the row has no visible version at that TID.
+            pg_sys::GetActiveSnapshot(),
+            &mut stats,
+        );
+
+        assert!(
+            slot.is_none(),
+            "a deleted row must not yield a visible tuple"
+        );
+        assert_eq!(
+            (*tupdesc).tdrefcount,
+            refcount_before,
+            "the rowtype TupleDesc pin must be released when there is no visible \
+             tuple (leak: issue #211)"
+        );
     }
 }


### PR DESCRIPTION
# Release scan resources deterministically: fix per-scan TupleDesc/slot leak and per-rescan state leak

Fixes #211.

## Summary

Two leaks on the diskann **scan** (rescore) path let a backend grow without bound.
The first is the `TupleDesc reference leak` reported in #211 — it is not a cosmetic
warning; it is accompanied by a leaked `TupleTableSlot` on every dead/invisible
rescored candidate, and on a table with ongoing `UPDATE`/`DELETE` traffic it grows
until the host runs out of memory.

## 1. `TupleTableSlot` + rowtype `TupleDesc` leaked when a heap pointer has no visible tuple

`TableSlot::from_index_heap_pointer` (`src/util/table_slot.rs`) creates the slot with
`table_slot_create`, which goes through `MakeTupleTableSlot` → `PinTupleDesc(rd_att)`
and so registers a descriptor pin on the current `ResourceOwner`. That pin — and the
slot itself — are released only by `TableSlot`'s `Drop`
(`ExecDropSingleTupleTableSlot`).

The wrapper was constructed **only on the success path**:

```rust
let slot = PgBox::from_pg(pg_sys::table_slot_create(heap_rel.as_ptr(), null_mut()));
// ... index_fetch_tuple ...
if !valid {
    return None;          // <-- slot never wrapped: slot + TupleDesc pin leak
}
Some(Self { slot })
```

`PgBox::from_pg` is non-owning, so its `Drop` is a no-op — the early return leaks both.
`!valid` is hit whenever `index_fetch_tuple` finds no snapshot-visible version in the
HOT chain (deleted, updated-away, or not-yet-vacuumed TIDs), which the scan explicitly
expects. It is reached from the rescore path — `get_full_distance_for_resort` in both
`sbq/storage.rs` and `plain/storage.rs`, driven by `next_with_resort` — and SBQ always
rescores, with resort on by default. So on a churned table this leaks **once per
rescored candidate**, and the descriptor pin surfaces as the `resource was not closed:
TupleDesc ... (<oid>,-1)` warning from #211.

Introduced by b480530 ("Fix HOT update handling"), which added the `!valid` early
return; before that the slot was always wrapped.

**Fix:** arm the RAII wrapper immediately after `table_slot_create` and fetch through
it, so every exit path — the early return and any unwind — drops the slot and releases
the descriptor. No caller changes: both callers already handle `None`.

## 2. Per-rescan `StorageState` accumulation, and `amendscan` freeing nothing

`TSVScanState::initialize` published the scan's `StorageState` with
`PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(...)`, i.e. tied to the
executor's **per-query** context. `amrescan` calls `initialize` again for every rescan
and **overwrote the pointer without dropping the previous state**, so a nested-loop or
lateral join orphaned one response iterator (plus a cloned `SbqQuantizer`) per outer
row, all held until the query ended. `amendscan`'s entire body was gated behind
`min_level <= DEBUG1` and freed nothing, so even a single scan's state lived until
per-query teardown.

**Fix:** make the state genuinely owned — `Box::into_raw` in `initialize` after
releasing the previous one, a `release_storage()` helper that nulls as it frees (so it
is idempotent), an unconditional release in `amendscan`, and a `Drop` impl on
`TSVScanState` as the backstop for scans torn down without `amendscan` (e.g. an aborted
query). The field stays a raw pointer so the existing call sites, which need
`&mut TSVScanState` alongside the state, are unchanged. `amendscan`'s debug-stats block
now tolerates a scan that was never rescanned instead of `expect`-ing storage.

## Impact (why #211 is not benign)

Observed on PostgreSQL 18.4 with pgvectorscale 0.9.0 serving a ~740k-row,
1024-dimension table under continuous re-indexing (so a steady supply of dead tuples),
with dense ANN queries plus lateral k-NN batch jobs:

- The `resource was not closed: TupleDesc ... (17176,-1)` warning fired at roughly
  **650/min**, one per rescored dead candidate.
- Six pooled backends grew to **7.6, 9.3, 13.4, 14.9, 17.4 and 19.5 GB** — about
  **82 GB** — and the host OOM-killed. Backends that were idle still held multiple GB,
  i.e. the growth was retained, not query working set.
- Cluster settings ruled out ordinary query memory: `work_mem = 4MB`,
  `maintenance_work_mem = 64MB`.
- Dropping the diskann index (reverting that workload to an HNSW index) removed the
  growth completely: the same workload then held ~1.4 GB across all backends and stayed
  flat.

## Minimal reproduction

PostgreSQL's own ResourceOwner reports each unreleased descriptor pin, so the leak is
directly observable without driving a backend to OOM. This takes a few hundred rows,
one query, and a couple of seconds:

```sql
CREATE EXTENSION IF NOT EXISTS vector;
CREATE EXTENSION IF NOT EXISTS vectorscale;

CREATE TABLE leak_mve (id int primary key, embedding vector(3));
INSERT INTO leak_mve
SELECT g, ('[' || g || ',' || (g % 7) || ',' || (g % 5) || ']')::vector
  FROM generate_series(1, 500) g;
CREATE INDEX leak_mve_diskann ON leak_mve USING diskann (embedding);

-- Make most index entries point at tuples that are no longer visible. No VACUUM on
-- purpose: the index still references those dead TIDs, which is the steady state of
-- any table with ongoing UPDATE/DELETE traffic.
DELETE FROM leak_mve WHERE id % 2 = 0;

SET enable_seqscan = off;      -- ensure the index scan (and so the rescore) runs
SET client_min_messages = warning;

SELECT id FROM leak_mve ORDER BY embedding <=> '[1,2,3]'::vector LIMIT 10;
```

On PostgreSQL 18.4 with pgvectorscale 0.9.0 (`57c88b7`), that single query prints:

```
WARNING:  resource was not closed: TupleDesc 0x7fc0f20d65c8 (16796,-1)
...                                                    (x60)
```

**60 slots and descriptor pins allocated and never freed by one small query.** `16796`
is `leak_mve`'s rowtype OID, and each line is one `TupleTableSlot` that
`table_slot_create` allocated and pinned but nothing ever dropped. Nothing here is
reclaimed until the ResourceOwner is torn down, and each is charged to the backend
until then — which is why a busy table walks a backend up into the tens of GB.

| Build | Dead tuples present | Leak warnings |
|---|---|---|
| 0.9.0 (unpatched) | yes | **60** |
| this PR | yes | **0** |
| 0.9.0 (control) | no — every tuple live | 0 |

The control run matters: with no dead tuples the rescore never takes the `!valid`
branch and nothing leaks, which localises the defect precisely to that early return.

### The same leak measured as backend memory

Scaling the reproduction up — 4 000 rows, half of them deleted, then ~8 000 index
rescans driven from a lateral join inside a **single** backend — shows the leaked
slots accumulating as resident memory. Same server, same query, only the extension
differs:

| elapsed | unpatched backend RSS | patched backend RSS |
|--------:|----------------------:|--------------------:|
|   3 s   |  182.6 MB             | 36.0 MB |
|   9 s   |  328.2 MB             | 36.0 MB |
|  15 s   |  388.0 MB             | 36.0 MB |
|  21 s   |  454.8 MB             | 36.0 MB |
|  24 s   |  493.6 MB (still climbing) | 36.0 MB |

Unpatched, the backend grows monotonically for as long as the workload runs and never
gives the memory back; patched, it is flat. Extrapolate that to a production table
under continuous churn and it is the 82 GB OOM described above.

## Verification

- **The regression test fails without the fix.** Reverting only the RAII change and
  re-running `table_slot_releases_tupledesc_on_dead_tuple` gives:
  ```
  assertion `left == right` failed: the rowtype TupleDesc pin must be released
  when there is no visible tuple (leak: issue #211)
    left: 2     <- descriptor refcount after the call
   right: 1     <- refcount before it
  ```
  With the fix the count is conserved and the test passes.
- **Full suite green:** `cargo pgrx test --no-default-features --features 'pg_test pg18 build_parallel' -- pg18`
  → `84 passed; 0 failed; 10 ignored` on PostgreSQL 18.4 (a `--enable-cassert`
  build), including both new tests.
- `cargo fmt --check` clean.

## Tests

- `util::table_slot::tests::table_slot_releases_tupledesc_on_dead_tuple` — inserts a
  row, records its TID, deletes it, and calls `from_index_heap_pointer` with a snapshot
  that cannot see it. Asserts the call returns `None` **and** that the relation's
  rowtype `TupleDesc` reference count is unchanged. Fails before the fix (the count is
  left incremented), passes after.
- `access_method::scan::tests::diskann_rescan_releases_state_each_iteration` — a
  lateral join that rescans the index once per outer row over a deliberately churned
  heap. Covers the rescan release path and would crash on a double free or
  use-after-free rather than merely leak.

Existing accuracy/scan suites are unchanged and still pass.