### PR TITLE
Bump version post-release to 0.9.2-dev

### DIFF
--- a/pgvectorscale/Cargo.toml
+++ b/pgvectorscale/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vectorscale"
-version = "0.9.1"
+version = "0.9.2-dev"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
0.9.1 has been released (https://github.com/timescale/pgvectorscale/releases/tag/0.9.1). This moves `main` to `0.9.2-dev`, following the post-release bump done in #230.

Version-only change in `pgvectorscale/Cargo.toml`; no SQL or upgrade-script changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)